### PR TITLE
[codex] Add agent-ready cost governance

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,2 +1,2 @@
 #!/bin/sh
-go run ./tools/commitlint --edit "$1"
+make commitlint COMMIT_MSG_FILE="$1"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,7 @@ This file is the execution guide for AI coding agents working in this repository
 
 `aitok` is an offline-first Go CLI for summarizing local token usage from Claude Code, Codex, and Gemini CLI.
 It may estimate USD costs from local token counts using an offline price catalog and local user overrides.
+Although it is a command-line tool for humans, product and engineering decisions should prioritize reliable invocation by AI agents and automation.
 
 Current codebase shape:
 
@@ -77,6 +78,9 @@ Before every product or harness iteration, do a short internal review:
 - Cost estimation must remain offline by default. Default prices may be updated from public provider pricing, but automatic network sync must be explicitly requested and opt-in.
 - Gemini CLI historical data depends on an existing local telemetry outfile. When it is not configured, report no parseable historical data.
 - CLI output must stay stable; JSON field changes need tests.
+- AI agents should treat `--format json` plus `--no-version-check` as the primary automation contract.
+- For JSON commands, stdout must remain a complete machine-readable JSON payload. Human-readable warnings, budget failures, and version prompts belong on stderr or in the returned error path.
+- Exit codes are part of the contract: `budget check` returns non-zero when the budget is exceeded while still writing the structured payload to stdout.
 - Markdown/table reports should remain readable and scriptable.
 - TUI must not replace CLI/JSON output; automation must be able to bypass TUI.
 - Production packages must not import `harness/` or `tools/`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,7 +38,7 @@ Out of scope unless explicitly requested:
 - Build: `make build`
 - Full local validation: `make validate`
 - PR metadata check: `make validate-pr-body`
-- Commit message check: `go run ./tools/commitlint --edit <commit-msg-file>`
+- Commit message check: `make commitlint COMMIT_MSG_FILE=<commit-msg-file>`
 - Run CLI directly: `go run ./cmd/aitok summary --period today`
 
 ## 3) Iteration Self-Constraint Protocol
@@ -107,7 +107,7 @@ Before every product or harness iteration, do a short internal review:
 
 - CI must run `make validate` and `make test-harness`.
 - PRs must include Summary, Requirement Classification, Acceptance Criteria, Changed Areas, TDD / Test Evidence, Validation, and Risk and Rollback.
-- Commit messages must match the repository Go commitlint format: `{emoji} {type}{scope}: {subject}`. Run `go run ./tools/commitlint --edit <commit-msg-file>` or install `.githooks/commit-msg` with `git config core.hooksPath .githooks`.
+- Commit messages must match the repository Go commitlint format: `{emoji} {type}{scope}: {subject}`. Run `make commitlint COMMIT_MSG_FILE=<commit-msg-file>` or install `.githooks/commit-msg` with `git config core.hooksPath .githooks`.
 - Do not claim completion after skipping local validation.
 - Stage/commit only files that belong to the current iteration; do not include unrelated dirty files.
 

--- a/AGENTS.zh-CN.md
+++ b/AGENTS.zh-CN.md
@@ -8,6 +8,7 @@
 
 `aitok` 是一个离线优先的 Go CLI，用于统计本机 Claude Code、Codex、Gemini CLI 的 Token 用量。
 它可以基于本地 Token 统计、离线价格表和用户本地覆盖配置预估 USD 成本。
+虽然它是面向人类用户的命令行工具，但产品和工程决策要优先保证 AI Agent 与自动化流程可以可靠调用。
 
 当前代码库形态：
 
@@ -77,6 +78,9 @@
 - 成本估算必须默认保持离线。默认价格可基于公开 provider 价格更新，但自动网络同步必须明确请求且显式 opt-in。
 - Gemini CLI 历史数据以已有 local telemetry outfile 为准；未开启时必须如实报告没有可解析历史数据。
 - CLI 输出必须稳定，JSON 字段变更需有测试覆盖。
+- AI Agent 应将 `--format json` 加 `--no-version-check` 作为主要自动化调用契约。
+- JSON 命令的 stdout 必须保持完整、可机器解析的 JSON payload。面向人类的 warning、预算失败摘要和版本提示应进入 stderr 或返回错误路径。
+- 退出码属于调用契约：`budget check` 预算超限时返回非零状态，但仍需把结构化 payload 写入 stdout。
 - Markdown/table 报告要保持可读且可脚本化。
 - TUI 不得替代 CLI/JSON 输出；自动化场景必须能绕过 TUI。
 - 生产代码不要依赖 `harness/` 或 `tools/`。

--- a/AGENTS.zh-CN.md
+++ b/AGENTS.zh-CN.md
@@ -38,7 +38,7 @@
 - 构建：`make build`
 - 完整本地验证：`make validate`
 - PR 元数据校验：`make validate-pr-body`
-- 提交消息检查：`go run ./tools/commitlint --edit <commit-msg-file>`
+- 提交消息检查：`make commitlint COMMIT_MSG_FILE=<commit-msg-file>`
 - 直接运行 CLI：`go run ./cmd/aitok summary --period today`
 
 ## 3) 迭代前自我约束流程
@@ -107,7 +107,7 @@
 
 - CI 必须运行 `make validate`、`make test-harness`。
 - PR 必须包含 Summary、Requirement Classification、Acceptance Criteria、Changed Areas、TDD / Test Evidence、Validation、Risk and Rollback。
-- 提交消息必须符合仓库内 Go commitlint 格式：`{emoji} {type}{scope}: {subject}`。可运行 `go run ./tools/commitlint --edit <commit-msg-file>`，或通过 `git config core.hooksPath .githooks` 启用 `.githooks/commit-msg`。
+- 提交消息必须符合仓库内 Go commitlint 格式：`{emoji} {type}{scope}: {subject}`。可运行 `make commitlint COMMIT_MSG_FILE=<commit-msg-file>`，或通过 `git config core.hooksPath .githooks` 启用 `.githooks/commit-msg`。
 - 不要绕过本地验证后声称完成。
 - Stage/commit 只包含当前迭代文件；不要纳入无关 dirty files。
 

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,13 @@
 GO ?= go
-AITOK_CACHE_DIR ?= /tmp/aitok-cache
+AITOK_CACHE_DIR ?= $(CURDIR)/.cache/aitok
 GOCACHE ?= $(AITOK_CACHE_DIR)/go-build
 GOMODCACHE ?= $(AITOK_CACHE_DIR)/go-mod
+COMMIT_MSG_FILE ?= .git/COMMIT_EDITMSG
 
-.PHONY: check test test-harness vet build validate validate-pr-body
+.PHONY: check test test-harness vet build validate validate-pr-body commitlint
 
 check:
-	@test -z "$$(gofmt -l .)"
+	@test -z "$$(gofmt -l $$(git ls-files '*.go'))"
 	GOCACHE=$(GOCACHE) GOMODCACHE=$(GOMODCACHE) $(GO) vet ./...
 
 test:
@@ -23,5 +24,8 @@ build:
 
 validate-pr-body:
 	GOCACHE=$(GOCACHE) GOMODCACHE=$(GOMODCACHE) $(GO) run ./tools/validate-pr-body
+
+commitlint:
+	GOCACHE=$(GOCACHE) GOMODCACHE=$(GOMODCACHE) $(GO) run ./tools/commitlint --edit "$(COMMIT_MSG_FILE)"
 
 validate: check test build

--- a/README.md
+++ b/README.md
@@ -46,7 +46,22 @@ aitok version
 aitok -v
 aitok update
 aitok setup gemini --dry-run
+aitok pricing audit --period this-month --format markdown
+aitok budget check --period this-month --limit-usd 20 --group-by tool,model,cwd
 ```
+
+## AI Agent Invocation
+
+AI agents and scripts should prefer JSON output and skip the low-frequency version check:
+
+```bash
+aitok --no-version-check summary --period today --format json
+aitok --no-version-check pricing audit --period this-month --format json
+aitok --no-version-check doctor --format json
+aitok --no-version-check budget check --period this-month --limit-usd 20 --format json
+```
+
+For JSON commands, stdout is reserved for the structured payload. Warnings, version prompts, and budget failure summaries are written to stderr or returned through the process exit status. `budget check` exits with status `1` when the limit is exceeded but still writes the full JSON payload to stdout for parsing.
 
 The TUI uses English by default. Pass `--lang zh-CN` to start in Chinese, or press `l` inside the TUI to switch languages.
 
@@ -97,6 +112,24 @@ aitok summary --pricing ./pricing.json --format json
 ```
 
 Prices are USD per 1M tokens. Reasoning tokens are charged as output tokens. `multiplier` defaults to `1`.
+
+To check whether local usage contains models that are not covered by the offline catalog or your override file:
+
+```bash
+aitok pricing audit --period this-month --format json
+```
+
+The audit stays offline and prints unmatched `tool/model/provider` groups plus a `pricing.json` skeleton that can be copied into `~/.aitok/pricing.json`.
+
+To enforce a local budget in scripts or CI:
+
+```bash
+aitok budget check --period this-month --limit-usd 20
+```
+
+The command exits with status `0` when the estimated cost is within the limit and status `1` when the estimate exceeds the limit. If some events do not match a price, the report includes a warning because the estimate may be low.
+
+`aitok doctor` also reports source event counts, latest event timestamps, Gemini local telemetry safety, and pricing coverage.
 
 ## Data Sources
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -46,7 +46,22 @@ aitok version
 aitok -v
 aitok update
 aitok setup gemini --dry-run
+aitok pricing audit --period this-month --format markdown
+aitok budget check --period this-month --limit-usd 20 --group-by tool,model,cwd
 ```
+
+## AI Agent 调用
+
+AI Agent 和脚本应优先使用 JSON 输出，并跳过低频版本检查：
+
+```bash
+aitok --no-version-check summary --period today --format json
+aitok --no-version-check pricing audit --period this-month --format json
+aitok --no-version-check doctor --format json
+aitok --no-version-check budget check --period this-month --limit-usd 20 --format json
+```
+
+对于 JSON 命令，stdout 只承载结构化 payload。warning、版本提示和预算失败摘要写入 stderr，或通过进程退出状态表达。`budget check` 超过限制时返回状态码 `1`，但仍会把完整 JSON payload 写入 stdout，便于 Agent 解析。
 
 TUI 默认使用英文文案。传入 `--lang zh-CN` 可默认显示中文，也可以在 TUI 中按 `l` 切换语言。
 
@@ -97,6 +112,24 @@ aitok summary --pricing ./pricing.json --format json
 ```
 
 价格单位是 USD / 1M tokens。Reasoning tokens 按 output tokens 计费。`multiplier` 默认是 `1`。
+
+如需检查本地用量中是否存在离线价格表或本地覆盖文件无法匹配的模型：
+
+```bash
+aitok pricing audit --period this-month --format json
+```
+
+该审计保持离线运行，会输出未匹配的 `tool/model/provider` 分组，并生成可复制到 `~/.aitok/pricing.json` 的价格 skeleton。
+
+如需在脚本或 CI 中检查本地预算：
+
+```bash
+aitok budget check --period this-month --limit-usd 20
+```
+
+当预估成本未超过限制时命令返回状态码 `0`，超过限制时返回状态码 `1`。如果部分事件没有匹配价格，报告会提示预估成本可能偏低。
+
+`aitok doctor` 也会报告数据源事件数、最近事件时间、Gemini 本地 telemetry 安全状态和价格覆盖率。
 
 ## 数据源
 

--- a/cmd/aitok/main.go
+++ b/cmd/aitok/main.go
@@ -38,6 +38,10 @@ func main() {
 		},
 	})
 	if err := cmd.Execute(); err != nil {
+		if cli.IsBudgetExceeded(err) {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}

--- a/docs/harness-engineering.md
+++ b/docs/harness-engineering.md
@@ -11,7 +11,7 @@ For `aitok`, the harness is intentionally lightweight: Go tests, a Makefile, PR 
 - `AGENTS.md` and `AGENTS.zh-CN.md`: repository mission, coding constraints, validation matrix, privacy boundaries, and handoff rules.
 - `README.md`: user-facing CLI usage and install path.
 - `CONTRIBUTING.md`: contributor validation and offline-first rules.
-- `Makefile`: canonical local commands: `make check`, `make test`, `make test-harness`, `make vet`, `make build`, `make validate`, and `make validate-pr-body`.
+- `Makefile`: canonical local commands: `make check`, `make test`, `make test-harness`, `make vet`, `make build`, `make validate`, `make validate-pr-body`, and `make commitlint`.
 - `tools/commitlint` and `.githooks/commit-msg`: repository-native Go commit-message validation for `{emoji} {type}{scope}: {subject}` without Node/npm tooling.
 - `.github/pull_request_template.md`: repeatable PR checklist for requirement classification, acceptance criteria, test evidence, validation, rollback, and residual risk.
 - `.github/workflows/ci.yml`: hosted validation matching the local gates.
@@ -23,7 +23,8 @@ For `aitok`, the harness is intentionally lightweight: Go tests, a Makefile, PR 
 - `go vet ./...`: static analysis.
 - `go build ./cmd/aitok`: single-binary build check.
 - `go run ./tools/validate-pr-body`: executable PR body metadata gate.
-- `go run ./tools/commitlint --edit <commit-msg-file>`: executable commit-message gate, optionally wired through `.githooks/commit-msg`.
+- `make commitlint COMMIT_MSG_FILE=<commit-msg-file>`: executable commit-message gate, optionally wired through `.githooks/commit-msg`.
+- `.cache/aitok/`: repository-local, git-ignored Go build/module cache used by Makefile targets so agent verification stays bound to this checkout instead of ad hoc `/tmp` paths.
 
 ## Agent Workflow Contract
 

--- a/docs/superpowers/plans/2026-05-09-aitok-local-cost-governance.md
+++ b/docs/superpowers/plans/2026-05-09-aitok-local-cost-governance.md
@@ -1,0 +1,69 @@
+# aitok 本地成本治理一期实施计划
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 构建性能优先、离线优先的本地成本治理闭环，覆盖流式聚合、价格覆盖率审计、预算检查和 doctor 深化。
+
+**Architecture:** 查询路径从“先收集全量事件再聚合”改为“source 逐行扫描并回调 accumulator”。新增命令复用同一套过滤、窗口、价格估算和报告格式，不引入网络同步、后台服务或持久预算配置。虽然 `aitok` 是命令行工具，但第一优先级是为 AI Agent 和自动化脚本提供稳定、可解析、可预期的调用契约。
+
+**Tech Stack:** Go 1.26.3+、Cobra CLI、标准库 JSON/文件扫描、现有 `internal/sources` / `internal/query` / `internal/pricing` / `internal/report` 边界。
+
+---
+
+## Summary
+
+第一期聚焦“性能优先、离线优先”的成本治理闭环：流式读取/聚合、价格覆盖率审计、预算检查、doctor 深化。暂不实现趋势对比和 git root 项目归一化，避免第一期范围过大。
+
+## Key Changes
+
+- 新增流式事件处理路径：在 `internal/sources` 增加逐事件扫描接口，Claude/Codex/Gemini 适配器边读 JSONL 边回调事件；保留现有 `Read()` 兼容测试和旧调用。
+- 在 `internal/query` 增加流式 accumulator，`summary/report/tui` 改为边扫描边聚合，不再为查询路径构建全量 `[]UsageEvent`。
+- 固化 AI Agent 调用契约：Agent 默认使用 `--format json --no-version-check`；JSON 命令 stdout 只输出结构化 payload，warning/错误摘要走 stderr 或退出码；预算超限时保留 stdout JSON 并返回非零状态。
+- 新增 `aitok pricing audit`：支持现有过滤、时间窗、价格文件和 `table|json|markdown`，输出未匹配价格的 `tool/model/provider`、事件数、token 数、示例 cwd，以及可复制的 `pricing.json` skeleton。
+- 新增 `aitok budget check --limit-usd <amount>`：复用现有过滤和分组参数；未超限 exit 0，超限 stdout 输出报告、stderr 输出摘要并 exit 1。
+- 增强 `aitok doctor --format table|json|markdown`：输出每个 source 状态、事件数、最近事件时间、Gemini telemetry 安全配置、价格覆盖率和未知模型数量。
+
+## Implementation Plan
+
+- Source/query 基础设施：
+  - 为 source 增加 `Scan(ctx, handle)` 能力，并用现有 `readJSONLines` 保持逐行解析。
+  - 新增 `sources.ForEach(ctx, sources, handle)`，聚合错误但不因单个 source 失败丢弃其他 source。
+  - 新增 `query.Accumulator`，封装 window/filter/group/cost 逻辑，结果排序保持与当前 `AggregateWithCosts` 一致。
+- CLI 命令：
+  - 把 `buildPayload` 改为流式 accumulator。
+  - 增加 `pricing audit` 子命令，内部只扫描一次日志并聚合未覆盖价格项。
+  - 增加 `budget check` 子命令，使用同一聚合结果计算总成本和超限状态。
+  - 扩展 `doctor`，不要调用全量 `Collect`；改为 source-by-source 流式扫描并收集诊断摘要。
+- Report/API：
+  - 保持现有 summary/report JSON 字段兼容。
+  - 新增独立 report payload：`pricing_audit` 和 `budget_check`，不要混入现有 `report.Payload`，避免破坏现有 JSON 用户。
+  - JSON stdout 是 Agent 契约，不得混入 warning、版本提示或人类说明文案。
+  - 表格和 Markdown 输出保持脚本可读，不使用交互式 UI。
+- Docs:
+  - 更新 `README.md` / `README.zh-CN.md`，补充 `pricing audit`、`budget check`、增强 doctor 示例。
+  - 若 PR 模板或 harness 规则未变化，不改 `.github/pull_request_template*` 或 harness docs。
+
+## Test Plan
+
+- Unit tests:
+  - Source 扫描测试：正常 JSONL、空目录、malformed JSONL、缺字段、重复事件仍按现有语义处理。
+  - Query accumulator 测试：与 `AggregateWithCosts` 在同一 fixture 下输出一致。
+  - Pricing audit 测试：已覆盖模型不出现，未知模型生成 skeleton，过滤条件生效。
+  - Budget check 测试：未超限 exit 0，超限返回错误，`--limit-usd <= 0` 报错，未知价格有 warning。
+  - Agent 调用契约测试：`--format json --no-version-check` 成功时 stderr 为空；预算超限时 stdout 保持完整 JSON，错误通过返回值/退出码表达。
+  - Doctor 测试：Gemini 未配置、`logPrompts=true`、正常配置三种状态。
+- CLI smoke:
+  - `go test ./internal/sources ./internal/query ./internal/pricing ./internal/report ./internal/cli`
+  - `make check`
+  - `make test`
+  - `make build`
+- Performance evidence:
+  - 增加 accumulator benchmark 或大 fixture 测试，记录 `go test ./internal/query -bench . -benchmem`。
+  - 验证新查询路径不再调用 `sources.Collect` 构建全量事件切片。
+
+## Assumptions
+
+- 第一期预算只支持命令参数，不引入 `~/.aitok/budget.json`。
+- 所有新增能力默认离线运行；不会新增网络同步、云上传、后台服务或 API key 读取。
+- 预算检查基于估算成本，不宣称等同 provider 账单。
+- 趋势对比和 git root 项目归一化作为第二期计划处理。

--- a/docs/zh-CN/harness-engineering.md
+++ b/docs/zh-CN/harness-engineering.md
@@ -11,7 +11,7 @@ Harness 是一组前馈指南和反馈传感器：前馈指南在代理编辑前
 - `AGENTS.md` 和 `AGENTS.zh-CN.md`：仓库使命、编码约束、验证矩阵、隐私边界和交付规则。
 - `README.md`：面向用户的 CLI 使用和安装路径。
 - `CONTRIBUTING.md`：贡献者验证和离线优先规则。
-- `Makefile`：标准本地命令：`make check`、`make test`、`make test-harness`、`make vet`、`make build`、`make validate`、`make validate-pr-body`。
+- `Makefile`：标准本地命令：`make check`、`make test`、`make test-harness`、`make vet`、`make build`、`make validate`、`make validate-pr-body` 和 `make commitlint`。
 - `tools/commitlint` 和 `.githooks/commit-msg`：仓库内 Go 提交消息校验，约束 `{emoji} {type}{scope}: {subject}`，不引入 Node/npm 工具链。
 - `.github/pull_request_template.md`：可重复的 PR 检查清单，覆盖需求分类、验收标准、测试证据、验证、回滚和残余风险。
 - `.github/workflows/ci.yml`：与本地门禁一致的托管验证。
@@ -23,7 +23,8 @@ Harness 是一组前馈指南和反馈传感器：前馈指南在代理编辑前
 - `go vet ./...`：静态分析。
 - `go build ./cmd/aitok`：单二进制构建检查。
 - `go run ./tools/validate-pr-body`：可执行 PR body 元数据门禁。
-- `go run ./tools/commitlint --edit <commit-msg-file>`：可执行提交消息门禁，可通过 `.githooks/commit-msg` 接入。
+- `make commitlint COMMIT_MSG_FILE=<commit-msg-file>`：可执行提交消息门禁，可通过 `.githooks/commit-msg` 接入。
+- `.cache/aitok/`：仓库内、git 忽略的 Go build/module cache，供 Makefile 目标使用，让 agent 校验绑定当前 checkout，而不是临时拼接 `/tmp` 路径。
 
 ## 代理工作流契约
 

--- a/harness/architecture_test.go
+++ b/harness/architecture_test.go
@@ -413,7 +413,7 @@ func TestWorkflowFilesKeepHarnessGates(t *testing.T) {
 	prTemplate := read(t, ".github", "pull_request_template.md")
 	gitignore := read(t, ".gitignore")
 
-	for _, target := range []string{"check:", "test:", "test-harness:", "build:", "validate-pr-body:", "validate:"} {
+	for _, target := range []string{"check:", "test:", "test-harness:", "build:", "validate-pr-body:", "commitlint:", "validate:"} {
 		if !strings.Contains(makefile, target) {
 			t.Fatalf("Makefile missing %s", target)
 		}
@@ -437,13 +437,19 @@ func TestWorkflowFilesKeepHarnessGates(t *testing.T) {
 			t.Fatalf("PR template missing %s", section)
 		}
 	}
-	if !strings.Contains(makefile, "AITOK_CACHE_DIR ?= /tmp/aitok-cache") {
-		t.Fatal("Makefile must default Go caches to a cross-platform runner-writable cache directory")
+	if !strings.Contains(makefile, "AITOK_CACHE_DIR ?= $(CURDIR)/.cache/aitok") {
+		t.Fatal("Makefile must default Go caches to the repository-local ignored cache directory")
 	}
-	for _, forbidden := range []string{"/private/tmp/aitok-gocache", "/private/tmp/aitok-gomodcache", "$(CURDIR)/$(AITOK_CACHE_DIR)"} {
+	if !strings.Contains(makefile, "gofmt -l $$(git ls-files '*.go')") {
+		t.Fatal("Makefile check must format only tracked Go source files")
+	}
+	for _, forbidden := range []string{"/tmp/aitok-cache", "/private/tmp/aitok-gocache", "/private/tmp/aitok-gomodcache", "$(CURDIR)/$(AITOK_CACHE_DIR)"} {
 		if strings.Contains(makefile, forbidden) {
-			t.Fatalf("Makefile must not default to macOS-only cache path %s", forbidden)
+			t.Fatalf("Makefile must not default to ad hoc temp cache path %s", forbidden)
 		}
+	}
+	if !strings.Contains(gitignore, ".cache/") {
+		t.Fatal(".gitignore must ignore the repository-local cache directory")
 	}
 	if !strings.Contains(gitignore, "/aitok") || strings.Contains(gitignore, "\naitok\n") {
 		t.Fatal(".gitignore must ignore only the root aitok binary, not cmd/aitok")
@@ -477,8 +483,8 @@ func TestCommitWorkflowConfigurationStaysExecutable(t *testing.T) {
 	}
 
 	hook := read(t, ".githooks", "commit-msg")
-	if !strings.Contains(hook, `go run ./tools/commitlint --edit "$1"`) {
-		t.Fatal(".githooks/commit-msg must run the Go commitlint tool")
+	if !strings.Contains(hook, `make commitlint COMMIT_MSG_FILE="$1"`) {
+		t.Fatal(".githooks/commit-msg must run the repository commitlint target")
 	}
 
 	docs := strings.Join([]string{
@@ -489,7 +495,7 @@ func TestCommitWorkflowConfigurationStaysExecutable(t *testing.T) {
 		read(t, ".github", "pull_request_template.md"),
 		read(t, ".github", "pull_request_template.zh-CN.md"),
 	}, "\n")
-	for _, expected := range []string{"go run ./tools/commitlint", ".githooks/commit-msg", "{emoji} {type}{scope}: {subject}"} {
+	for _, expected := range []string{"make commitlint COMMIT_MSG_FILE=", ".githooks/commit-msg", "{emoji} {type}{scope}: {subject}"} {
 		if !strings.Contains(docs, expected) {
 			t.Fatalf("agent and PR docs must mention %s", expected)
 		}

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -161,7 +161,9 @@ func New(app App) *cobra.Command {
 				return err
 			}
 			if payload.UnpricedEvents > 0 {
-				fmt.Fprintf(app.Err, "warning: %d events had no matching price; estimated cost may be low\n", payload.UnpricedEvents)
+				if _, err := fmt.Fprintf(app.Err, "warning: %d events had no matching price; estimated cost may be low\n", payload.UnpricedEvents); err != nil {
+					return err
+				}
 			}
 			if payload.Exceeded {
 				return budgetExceededError{Limit: payload.LimitUSD, Total: payload.TotalUSD}

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -509,6 +509,15 @@ func inspectGemini(home string) report.DoctorGeminiState {
 	if telemetry == nil {
 		return state
 	}
+	enabled, hasEnabled := telemetry["enabled"].(bool)
+	if !hasEnabled || !enabled {
+		state.Status = "telemetry disabled"
+		return state
+	}
+	if target := stringFromAny(telemetry["target"]); target != "local" {
+		state.Status = "telemetry target not local"
+		return state
+	}
 	state.Configured = true
 	state.Outfile = expandHomeForCLI(home, stringFromAny(telemetry["outfile"]))
 	logPrompts, hasLogPrompts := telemetry["logPrompts"].(bool)

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -3,9 +3,13 @@ package cli
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
+	"sort"
+	"strings"
 	"time"
 
 	"github.com/MagnumGoYB/aitok/internal/buildinfo"
@@ -57,6 +61,7 @@ type flags struct {
 	dryRun         bool
 	noVersionCheck bool
 	version        bool
+	limitUSD       float64
 }
 
 func New(app App) *cobra.Command {
@@ -122,6 +127,52 @@ func New(app App) *cobra.Command {
 	}
 	addQueryFlags(reportCmd, f)
 
+	pricingCmd := &cobra.Command{
+		Use:   "pricing",
+		Short: "Inspect offline pricing coverage",
+	}
+	pricingAudit := &cobra.Command{
+		Use:   "audit",
+		Short: "Report local usage events without matching prices",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			payload, err := buildPricingAudit(cmd.Context(), f, app.Now())
+			if err != nil {
+				return err
+			}
+			return report.WritePricingAudit(app.Out, f.format, payload)
+		},
+	}
+	addQueryFlags(pricingAudit, f)
+	pricingCmd.AddCommand(pricingAudit)
+
+	budgetCmd := &cobra.Command{
+		Use:   "budget",
+		Short: "Check local estimated usage cost against a budget",
+	}
+	budgetCheck := &cobra.Command{
+		Use:   "check",
+		Short: "Fail when estimated local usage cost exceeds a limit",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			payload, err := buildBudgetCheck(cmd.Context(), f, app.Now())
+			if err != nil {
+				return err
+			}
+			if err := report.WriteBudget(app.Out, f.format, payload); err != nil {
+				return err
+			}
+			if payload.UnpricedEvents > 0 {
+				fmt.Fprintf(app.Err, "warning: %d events had no matching price; estimated cost may be low\n", payload.UnpricedEvents)
+			}
+			if payload.Exceeded {
+				return budgetExceededError{Limit: payload.LimitUSD, Total: payload.TotalUSD}
+			}
+			return nil
+		},
+	}
+	addQueryFlags(budgetCheck, f)
+	budgetCheck.Flags().Float64Var(&f.limitUSD, "limit-usd", 0, "budget limit in USD; required and must be greater than 0")
+	budgetCmd.AddCommand(budgetCheck)
+
 	tuiCmd := &cobra.Command{
 		Use:   "tui",
 		Short: "Open the terminal dashboard",
@@ -148,9 +199,14 @@ func New(app App) *cobra.Command {
 		Use:   "doctor",
 		Short: "Inspect local data source availability",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runDoctor(cmd.Context(), app.Out, f.home)
+			payload, err := buildDoctor(cmd.Context(), f, app.Now())
+			if err != nil {
+				return err
+			}
+			return report.WriteDoctor(app.Out, f.format, payload)
 		},
 	}
+	doctor.Flags().StringVar(&f.format, "format", "table", "format: table, json, markdown")
 
 	versionCmd := &cobra.Command{
 		Use:   "version",
@@ -201,7 +257,7 @@ func New(app App) *cobra.Command {
 	gemini.Flags().StringVar(&f.format, "format", "table", "output format: table or json")
 	setupCmd.AddCommand(gemini)
 
-	root.AddCommand(summary, reportCmd, tuiCmd, doctor, versionCmd, updateCmd, setupCmd)
+	root.AddCommand(summary, reportCmd, pricingCmd, budgetCmd, tuiCmd, doctor, versionCmd, updateCmd, setupCmd)
 	return root
 }
 
@@ -231,23 +287,27 @@ func buildPayload(ctx context.Context, f *flags, now time.Time) (report.Payload,
 	}
 	window := query.WindowFor(period, now, time.Local)
 	opts := sources.Options{Home: resolveHome(f.home)}
-	events, err := sources.Collect(ctx, sources.Defaults(opts))
-	if err != nil {
-		return report.Payload{}, err
-	}
 	catalog, err := loadPricing(f, opts.Home)
 	if err != nil {
 		return report.Payload{}, err
 	}
-	results := query.AggregateWithCosts(events, window, query.Filters{
+	groupBy := query.ParseGroupBy(f.groupBy)
+	acc := query.NewAccumulator(window, query.Filters{
 		Tools:     query.SplitCSV(f.tools),
 		Models:    query.SplitCSV(f.models),
 		Providers: query.SplitCSV(f.providers),
 		CWD:       f.cwd,
-	}, query.ParseGroupBy(f.groupBy), func(event usage.UsageEvent) query.Cost {
+	}, groupBy, func(event usage.UsageEvent) query.Cost {
 		return query.Cost{USD: catalog.CostFor(event).USD}
 	})
-	return report.Payload{GeneratedAt: now, Window: window, GroupBy: query.ParseGroupBy(f.groupBy), Results: results}, nil
+	err = sources.ForEach(ctx, sources.Defaults(opts), func(event usage.UsageEvent) error {
+		acc.Add(event)
+		return nil
+	})
+	if err != nil {
+		return report.Payload{}, err
+	}
+	return report.Payload{GeneratedAt: now, Window: window, GroupBy: groupBy, Results: acc.Results()}, nil
 }
 
 func loadPricing(f *flags, home string) (pricing.Catalog, error) {
@@ -265,17 +325,254 @@ func loadPricing(f *flags, home string) (pricing.Catalog, error) {
 	return catalog, nil
 }
 
-func runDoctor(ctx context.Context, out io.Writer, home string) error {
-	opts := sources.Options{Home: resolveHome(home)}
-	for _, source := range sources.Defaults(opts) {
-		events, err := source.Read(ctx)
-		status := "ok"
-		if err != nil {
-			status = err.Error()
-		}
-		fmt.Fprintf(out, "%s\t%d events\t%s\n", source.Name(), len(events), status)
+type budgetExceededError struct {
+	Limit float64
+	Total float64
+}
+
+func (e budgetExceededError) Error() string {
+	return fmt.Sprintf("budget exceeded: total %s > limit %s", report.FormatUSD(e.Total), report.FormatUSD(e.Limit))
+}
+
+func buildBudgetCheck(ctx context.Context, f *flags, now time.Time) (report.BudgetPayload, error) {
+	if f.limitUSD <= 0 {
+		return report.BudgetPayload{}, fmt.Errorf("--limit-usd must be greater than 0")
 	}
-	return nil
+	period, err := query.ParsePeriod(f.period)
+	if err != nil {
+		return report.BudgetPayload{}, err
+	}
+	window := query.WindowFor(period, now, time.Local)
+	opts := sources.Options{Home: resolveHome(f.home)}
+	catalog, err := loadPricing(f, opts.Home)
+	if err != nil {
+		return report.BudgetPayload{}, err
+	}
+	groupBy := query.ParseGroupBy(f.groupBy)
+	filters := query.Filters{Tools: query.SplitCSV(f.tools), Models: query.SplitCSV(f.models), Providers: query.SplitCSV(f.providers), CWD: f.cwd}
+	acc := query.NewAccumulator(window, filters, groupBy, func(event usage.UsageEvent) query.Cost {
+		return query.Cost{USD: catalog.CostFor(event).USD}
+	})
+	var unpriced unpricedPricingCount
+	err = sources.ForEach(ctx, sources.Defaults(opts), func(event usage.UsageEvent) error {
+		if !window.Contains(event.Timestamp) || !eventMatches(event, filters) {
+			return nil
+		}
+		if !catalog.Covers(event) {
+			unpriced.Events++
+			unpriced.Tokens += event.Usage.NormalizedTotal()
+		}
+		acc.Add(event)
+		return nil
+	})
+	if err != nil {
+		return report.BudgetPayload{}, err
+	}
+	results := acc.Results()
+	var total float64
+	for _, result := range results {
+		total += result.CostUSD
+	}
+	return report.BudgetPayload{
+		GeneratedAt:    now,
+		Window:         window,
+		LimitUSD:       f.limitUSD,
+		TotalUSD:       total,
+		Exceeded:       total > f.limitUSD,
+		UnpricedEvents: unpriced.Events,
+		UnpricedTokens: unpriced.Tokens,
+		Results:        results,
+	}, nil
+}
+
+type unpricedPricingCount struct {
+	Events int
+	Tokens int64
+}
+
+func buildPricingAudit(ctx context.Context, f *flags, now time.Time) (report.PricingAuditPayload, error) {
+	period, err := query.ParsePeriod(f.period)
+	if err != nil {
+		return report.PricingAuditPayload{}, err
+	}
+	window := query.WindowFor(period, now, time.Local)
+	opts := sources.Options{Home: resolveHome(f.home)}
+	catalog, err := loadPricing(f, opts.Home)
+	if err != nil {
+		return report.PricingAuditPayload{}, err
+	}
+	filters := query.Filters{Tools: query.SplitCSV(f.tools), Models: query.SplitCSV(f.models), Providers: query.SplitCSV(f.providers), CWD: f.cwd}
+	type bucket struct {
+		item report.PricingAuditResult
+	}
+	buckets := map[string]*bucket{}
+	err = sources.ForEach(ctx, sources.Defaults(opts), func(event usage.UsageEvent) error {
+		if !window.Contains(event.Timestamp) || !eventMatches(event, filters) || catalog.Covers(event) {
+			return nil
+		}
+		model := usage.Unknown(event.Model)
+		provider := usage.Unknown(event.Provider)
+		key := string(event.Tool) + "|" + model + "|" + provider
+		if buckets[key] == nil {
+			buckets[key] = &bucket{item: report.PricingAuditResult{Tool: string(event.Tool), Model: model, Provider: provider, Example: event.CWD}}
+		}
+		buckets[key].item.Events++
+		buckets[key].item.Usage = buckets[key].item.Usage.Add(event.Usage)
+		if buckets[key].item.Example == "" {
+			buckets[key].item.Example = event.CWD
+		}
+		return nil
+	})
+	if err != nil {
+		return report.PricingAuditPayload{}, err
+	}
+	unpriced := make([]report.PricingAuditResult, 0, len(buckets))
+	for _, bucket := range buckets {
+		unpriced = append(unpriced, bucket.item)
+	}
+	sort.Slice(unpriced, func(i, j int) bool {
+		left := unpriced[i].Usage.NormalizedTotal()
+		right := unpriced[j].Usage.NormalizedTotal()
+		if left == right {
+			return unpriced[i].Tool+"|"+unpriced[i].Model+"|"+unpriced[i].Provider < unpriced[j].Tool+"|"+unpriced[j].Model+"|"+unpriced[j].Provider
+		}
+		return left > right
+	})
+	return report.PricingAuditPayload{GeneratedAt: now, Window: window, Unpriced: unpriced, Skeleton: pricingSkeleton(unpriced)}, nil
+}
+
+func pricingSkeleton(items []report.PricingAuditResult) string {
+	if len(items) == 0 {
+		return ""
+	}
+	var b strings.Builder
+	b.WriteString("{\n  \"models\": [\n")
+	for i, item := range items {
+		if i > 0 {
+			b.WriteString(",\n")
+		}
+		fmt.Fprintf(&b, "    {\n      \"match\": %q,\n      \"provider\": %q,\n      \"input_usd_per_mtok\": 0,\n      \"output_usd_per_mtok\": 0,\n      \"cache_hit_usd_per_mtok\": 0,\n      \"cache_make_usd_per_mtok\": 0,\n      \"multiplier\": 1\n    }", item.Model, item.Provider)
+	}
+	b.WriteString("\n  ]\n}\n")
+	return b.String()
+}
+
+func buildDoctor(ctx context.Context, f *flags, now time.Time) (report.DoctorPayload, error) {
+	opts := sources.Options{Home: resolveHome(f.home)}
+	catalog, err := loadPricing(f, opts.Home)
+	if err != nil {
+		return report.DoctorPayload{}, err
+	}
+	var payload report.DoctorPayload
+	payload.GeneratedAt = now
+	payload.Gemini = inspectGemini(opts.Home)
+	unpricedModels := map[string]struct{}{}
+	for _, source := range sources.Defaults(opts) {
+		result := report.DoctorSource{Name: string(source.Name()), Status: "ok"}
+		err := source.Scan(ctx, func(event usage.UsageEvent) error {
+			result.Events++
+			if result.LatestEvent == nil || event.Timestamp.After(*result.LatestEvent) {
+				ts := event.Timestamp
+				result.LatestEvent = &ts
+			}
+			if catalog.Covers(event) {
+				payload.Pricing.PricedEvents++
+			} else {
+				payload.Pricing.UnpricedEvents++
+				payload.Pricing.UnpricedTokens += event.Usage.NormalizedTotal()
+				unpricedModels[string(event.Tool)+"|"+usage.Unknown(event.Model)+"|"+usage.Unknown(event.Provider)] = struct{}{}
+			}
+			return nil
+		})
+		if err != nil {
+			result.Status = err.Error()
+		}
+		payload.Sources = append(payload.Sources, result)
+	}
+	payload.Pricing.UnpricedModels = len(unpricedModels)
+	return payload, nil
+}
+
+func inspectGemini(home string) report.DoctorGeminiState {
+	settingsPath := filepath.Join(home, ".gemini", "settings.json")
+	state := report.DoctorGeminiState{SettingsPath: settingsPath, Status: "not configured"}
+	data, err := os.ReadFile(settingsPath)
+	if err != nil {
+		return state
+	}
+	var settings map[string]any
+	if err := json.Unmarshal(data, &settings); err != nil {
+		state.Status = "settings parse error"
+		return state
+	}
+	telemetry, _ := settings["telemetry"].(map[string]any)
+	if telemetry == nil {
+		return state
+	}
+	state.Configured = true
+	state.Outfile = expandHomeForCLI(home, stringFromAny(telemetry["outfile"]))
+	logPrompts, hasLogPrompts := telemetry["logPrompts"].(bool)
+	state.LogPromptsSafe = hasLogPrompts && !logPrompts
+	if state.Outfile == "" {
+		state.Status = "telemetry outfile missing"
+		return state
+	}
+	if !state.LogPromptsSafe {
+		state.Status = "logPrompts is not false"
+		return state
+	}
+	state.Status = "ok"
+	return state
+}
+
+func expandHomeForCLI(home, path string) string {
+	if path == "" {
+		return ""
+	}
+	if path == "~" {
+		return home
+	}
+	if len(path) > 2 && path[0] == '~' && os.IsPathSeparator(path[1]) {
+		return filepath.Join(home, path[2:])
+	}
+	return path
+}
+
+func stringFromAny(value any) string {
+	if out, ok := value.(string); ok {
+		return out
+	}
+	return ""
+}
+
+func eventMatches(event usage.UsageEvent, filters query.Filters) bool {
+	if len(filters.Tools) > 0 && !containsString(filters.Tools, string(event.Tool)) {
+		return false
+	}
+	if len(filters.Models) > 0 && !containsString(filters.Models, event.Model) {
+		return false
+	}
+	if len(filters.Providers) > 0 && !containsString(filters.Providers, event.Provider) {
+		return false
+	}
+	if filters.CWD != "" && !strings.Contains(event.CWD, filters.CWD) {
+		return false
+	}
+	return true
+}
+
+func containsString(values []string, target string) bool {
+	for _, value := range values {
+		if strings.EqualFold(strings.TrimSpace(value), target) {
+			return true
+		}
+	}
+	return false
+}
+
+func IsBudgetExceeded(err error) bool {
+	var budgetErr budgetExceededError
+	return errors.As(err, &budgetErr)
 }
 
 func resolveHome(home string) string {

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"io"
 	"os"
 	"path/filepath"
@@ -58,7 +59,15 @@ func TestAgentJSONSummaryKeepsStdoutMachineReadableAndStderrEmpty(t *testing.T) 
 	if stderr.Len() != 0 {
 		t.Fatalf("agent JSON command should keep stderr empty on success: %s", stderr.String())
 	}
-	if !strings.HasPrefix(strings.TrimSpace(out.String()), "{") || !strings.Contains(out.String(), `"results"`) {
+	var payload struct {
+		Results []struct {
+			Key map[string]string `json:"key"`
+		} `json:"results"`
+	}
+	if err := json.Unmarshal(out.Bytes(), &payload); err != nil {
+		t.Fatalf("stdout should be a complete JSON object: %v\n%s", err, out.String())
+	}
+	if len(payload.Results) != 1 || payload.Results[0].Key["tool"] != "codex" {
 		t.Fatalf("stdout should be a JSON object: %s", out.String())
 	}
 }
@@ -243,6 +252,38 @@ func TestDoctorReportsGeminiSafetyAndPricing(t *testing.T) {
 	}
 	if !strings.Contains(out.String(), `"log_prompts_safe": true`) || !strings.Contains(out.String(), `"unpriced_events": 1`) {
 		t.Fatalf("doctor output missing gemini safety or pricing diagnostics: %s", out.String())
+	}
+}
+
+func TestDoctorRequiresGeminiLocalTelemetryEnabled(t *testing.T) {
+	tests := []struct {
+		name     string
+		settings string
+		status   string
+	}{
+		{
+			name:     "disabled",
+			settings: `{"telemetry":{"enabled":false,"target":"local","outfile":"~/.gemini/telemetry.log","logPrompts":false}}`,
+			status:   "telemetry disabled",
+		},
+		{
+			name:     "not local",
+			settings: `{"telemetry":{"enabled":true,"target":"gcp","outfile":"~/.gemini/telemetry.log","logPrompts":false}}`,
+			status:   "telemetry target not local",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			home := t.TempDir()
+			writeFixture(t, filepath.Join(home, ".gemini", "settings.json"), tt.settings)
+			state := inspectGemini(home)
+			if state.Configured {
+				t.Fatalf("configured = true, want false")
+			}
+			if state.Status != tt.status {
+				t.Fatalf("status = %q, want %q", state.Status, tt.status)
+			}
+		})
 	}
 }
 

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -32,6 +32,37 @@ func TestSummaryIntegrationJSON(t *testing.T) {
 	}
 }
 
+func TestAgentJSONSummaryKeepsStdoutMachineReadableAndStderrEmpty(t *testing.T) {
+	home := t.TempDir()
+	writeFixture(t, filepath.Join(home, ".codex", "sessions", "2026", "05", "08", "rollout.jsonl"),
+		`{"type":"session_meta","timestamp":"2026-05-08T01:00:00Z","payload":{"model_provider":"openai","cwd":"/repo"}}`+"\n"+
+			`{"type":"turn_context","timestamp":"2026-05-08T01:00:01Z","payload":{"model":"gpt-5.4","cwd":"/repo"}}`+"\n"+
+			`{"type":"event_msg","timestamp":"2026-05-08T01:00:02Z","payload":{"type":"token_count","info":{"last_token_usage":{"input_tokens":10,"output_tokens":2,"total_tokens":12}}}}`+"\n")
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd := New(App{
+		Out: &out,
+		Err: &stderr,
+		VersionCheck: func(ctx context.Context, opts VersionCheckOptions) error {
+			t.Fatal("agent commands should use --no-version-check")
+			return nil
+		},
+		Now: func() time.Time {
+			return time.Date(2026, 5, 8, 12, 0, 0, 0, time.UTC)
+		},
+	})
+	cmd.SetArgs([]string{"--home", home, "--no-version-check", "summary", "--period", "today", "--format", "json"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("agent JSON command should keep stderr empty on success: %s", stderr.String())
+	}
+	if !strings.HasPrefix(strings.TrimSpace(out.String()), "{") || !strings.Contains(out.String(), `"results"`) {
+		t.Fatalf("stdout should be a JSON object: %s", out.String())
+	}
+}
+
 func TestSummaryUsesCustomPricingFile(t *testing.T) {
 	home := t.TempDir()
 	pricingPath := filepath.Join(home, "pricing.json")
@@ -105,6 +136,113 @@ func TestSetupGeminiDryRunCommand(t *testing.T) {
 	}
 	if !strings.Contains(out.String(), "Dry run: true") || !strings.Contains(out.String(), "logPrompts") {
 		t.Fatalf("unexpected output: %s", out.String())
+	}
+}
+
+func TestPricingAuditReportsUnpricedModels(t *testing.T) {
+	home := t.TempDir()
+	writeFixture(t, filepath.Join(home, ".codex", "sessions", "2026", "05", "08", "rollout.jsonl"),
+		`{"type":"turn_context","timestamp":"2026-05-08T01:00:01Z","payload":{"model":"mystery-model","cwd":"/repo"}}`+"\n"+
+			`{"type":"event_msg","timestamp":"2026-05-08T01:00:02Z","payload":{"type":"token_count","info":{"last_token_usage":{"input_tokens":10,"output_tokens":2}}}}`+"\n")
+	var out bytes.Buffer
+	cmd := New(App{Out: &out, Now: func() time.Time {
+		return time.Date(2026, 5, 8, 12, 0, 0, 0, time.UTC)
+	}})
+	cmd.SetArgs([]string{"--home", home, "pricing", "audit", "--period", "today", "--format", "json"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out.String(), `"model": "mystery-model"`) || !strings.Contains(out.String(), `"skeleton"`) {
+		t.Fatalf("pricing audit missing unpriced model and skeleton: %s", out.String())
+	}
+}
+
+func TestPricingAuditOmitsKnownModels(t *testing.T) {
+	home := t.TempDir()
+	writeFixture(t, filepath.Join(home, ".codex", "sessions", "2026", "05", "08", "rollout.jsonl"),
+		`{"type":"turn_context","timestamp":"2026-05-08T01:00:01Z","payload":{"model":"gpt-5.4","cwd":"/repo"}}`+"\n"+
+			`{"type":"event_msg","timestamp":"2026-05-08T01:00:02Z","payload":{"type":"token_count","info":{"last_token_usage":{"input_tokens":10,"output_tokens":2}}}}`+"\n")
+	var out bytes.Buffer
+	cmd := New(App{Out: &out, Now: func() time.Time {
+		return time.Date(2026, 5, 8, 12, 0, 0, 0, time.UTC)
+	}})
+	cmd.SetArgs([]string{"--home", home, "pricing", "audit", "--period", "today", "--format", "json"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out.String(), `"unpriced": []`) {
+		t.Fatalf("known model should not appear in pricing audit: %s", out.String())
+	}
+}
+
+func TestBudgetCheckFailsWhenLimitExceeded(t *testing.T) {
+	home := t.TempDir()
+	writeFixture(t, filepath.Join(home, ".codex", "sessions", "2026", "05", "08", "rollout.jsonl"),
+		`{"type":"session_meta","timestamp":"2026-05-08T01:00:00Z","payload":{"model_provider":"openai","cwd":"/repo"}}`+"\n"+
+			`{"type":"turn_context","timestamp":"2026-05-08T01:00:01Z","payload":{"model":"gpt-5.4","cwd":"/repo"}}`+"\n"+
+			`{"type":"event_msg","timestamp":"2026-05-08T01:00:02Z","payload":{"type":"token_count","info":{"last_token_usage":{"input_tokens":1000000,"output_tokens":1000000}}}}`+"\n")
+	var out bytes.Buffer
+	cmd := New(App{Out: &out, Now: func() time.Time {
+		return time.Date(2026, 5, 8, 12, 0, 0, 0, time.UTC)
+	}})
+	cmd.SetArgs([]string{"--home", home, "budget", "check", "--period", "today", "--limit-usd", "1", "--format", "json"})
+	err := cmd.Execute()
+	if !IsBudgetExceeded(err) {
+		t.Fatalf("err = %v, want budget exceeded", err)
+	}
+	if !strings.Contains(out.String(), `"exceeded": true`) || !strings.Contains(out.String(), `"limit_usd": 1`) {
+		t.Fatalf("budget output missing exceeded payload: %s", out.String())
+	}
+}
+
+func TestAgentBudgetExceededKeepsPayloadOnStdoutAndSummaryOnStderr(t *testing.T) {
+	home := t.TempDir()
+	writeFixture(t, filepath.Join(home, ".codex", "sessions", "2026", "05", "08", "rollout.jsonl"),
+		`{"type":"session_meta","timestamp":"2026-05-08T01:00:00Z","payload":{"model_provider":"openai","cwd":"/repo"}}`+"\n"+
+			`{"type":"turn_context","timestamp":"2026-05-08T01:00:01Z","payload":{"model":"gpt-5.4","cwd":"/repo"}}`+"\n"+
+			`{"type":"event_msg","timestamp":"2026-05-08T01:00:02Z","payload":{"type":"token_count","info":{"last_token_usage":{"input_tokens":1000000,"output_tokens":1000000}}}}`+"\n")
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd := New(App{Out: &out, Err: &stderr, Now: func() time.Time {
+		return time.Date(2026, 5, 8, 12, 0, 0, 0, time.UTC)
+	}})
+	cmd.SetArgs([]string{"--home", home, "--no-version-check", "budget", "check", "--period", "today", "--limit-usd", "1", "--format", "json"})
+	err := cmd.Execute()
+	if !IsBudgetExceeded(err) {
+		t.Fatalf("err = %v, want budget exceeded", err)
+	}
+	stdout := out.String()
+	if !strings.HasPrefix(strings.TrimSpace(stdout), "{") || !strings.Contains(stdout, `"exceeded": true`) || !strings.Contains(stdout, `"unpriced_events"`) {
+		t.Fatalf("stdout should keep complete budget JSON payload: %s", stdout)
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("library command should not write stderr directly; main handles returned error: %s", stderr.String())
+	}
+}
+
+func TestBudgetCheckRequiresPositiveLimit(t *testing.T) {
+	cmd := New(App{Out: io.Discard})
+	cmd.SetArgs([]string{"budget", "check", "--limit-usd", "0"})
+	if err := cmd.Execute(); err == nil || !strings.Contains(err.Error(), "--limit-usd must be greater than 0") {
+		t.Fatalf("err = %v, want positive limit error", err)
+	}
+}
+
+func TestDoctorReportsGeminiSafetyAndPricing(t *testing.T) {
+	home := t.TempDir()
+	writeFixture(t, filepath.Join(home, ".gemini", "settings.json"), `{"telemetry":{"enabled":true,"target":"local","outfile":"~/.gemini/telemetry.log","logPrompts":false}}`)
+	writeFixture(t, filepath.Join(home, ".gemini", "telemetry.log"),
+		`{"timestamp":"2026-05-08T01:00:00Z","name":"gemini_cli.api_response","attributes":{"model":"unknown-gemini","auth_type":"oauth","input_token_count":11,"output_token_count":5,"prompt_id":"p1"}}`+"\n")
+	var out bytes.Buffer
+	cmd := New(App{Out: &out, Now: func() time.Time {
+		return time.Date(2026, 5, 8, 12, 0, 0, 0, time.UTC)
+	}})
+	cmd.SetArgs([]string{"--home", home, "doctor", "--format", "json"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out.String(), `"log_prompts_safe": true`) || !strings.Contains(out.String(), `"unpriced_events": 1`) {
+		t.Fatalf("doctor output missing gemini safety or pricing diagnostics: %s", out.String())
 	}
 }
 

--- a/internal/pricing/pricing.go
+++ b/internal/pricing/pricing.go
@@ -57,6 +57,7 @@ func Load(home string) (Catalog, error) {
 
 func DefaultCatalog() Catalog {
 	return Catalog{Models: []ModelPrice{
+		{Match: "codex-auto-review", Provider: "bcb", InputUSDPerMTok: 5, OutputUSDPerMTok: 30, CacheHitUSDPerMTok: 0.5, CacheMakeUSDPerMTok: 5, Multiplier: 1, Source: "default"},
 		{Match: "gpt-5.5", Provider: "openai", InputUSDPerMTok: 5, OutputUSDPerMTok: 30, CacheHitUSDPerMTok: 0.5, CacheMakeUSDPerMTok: 5, Multiplier: 1, Source: "default"},
 		{Match: "gpt-5.4-mini", Provider: "openai", InputUSDPerMTok: 0.75, OutputUSDPerMTok: 4.5, CacheHitUSDPerMTok: 0.075, CacheMakeUSDPerMTok: 0.75, Multiplier: 1, Source: "default"},
 		{Match: "gpt-5.4", Provider: "openai", InputUSDPerMTok: 2.5, OutputUSDPerMTok: 15, CacheHitUSDPerMTok: 0.25, CacheMakeUSDPerMTok: 2.5, Multiplier: 1, Source: "default"},
@@ -90,6 +91,11 @@ func (c Catalog) CostFor(event usage.UsageEvent) Cost {
 		perMillion(event.Usage.CachedInput, price.CacheHitUSDPerMTok) +
 		perMillion(event.Usage.CacheCreation, cacheMake)
 	return Cost{USD: usd * multiplier, Currency: "USD", Multiplier: multiplier, Source: price.Source}
+}
+
+func (c Catalog) Covers(event usage.UsageEvent) bool {
+	_, ok := c.match(event)
+	return ok
 }
 
 func billableInput(event usage.UsageEvent) int64 {

--- a/internal/pricing/pricing_test.go
+++ b/internal/pricing/pricing_test.go
@@ -127,3 +127,18 @@ func TestLoadIgnoresMissingUserConfig(t *testing.T) {
 		t.Fatalf("default catalog did not price known model: %+v", cost)
 	}
 }
+
+func TestDefaultCatalogCoversCodexAutoReview(t *testing.T) {
+	cost := DefaultCatalog().CostFor(usage.UsageEvent{
+		Tool:     usage.ToolCodex,
+		Model:    "codex-auto-review",
+		Provider: "bcb",
+		Usage:    usage.TokenUsage{Input: 1_000_000, Output: 100_000, CachedInput: 800_000},
+	})
+	if cost.USD <= 0 {
+		t.Fatalf("codex-auto-review should be priced by default: %+v", cost)
+	}
+	if cost.Source != "default" {
+		t.Fatalf("source = %q, want default", cost.Source)
+	}
+}

--- a/internal/query/query.go
+++ b/internal/query/query.go
@@ -30,6 +30,14 @@ type Result struct {
 	Examples map[string]string `json:"examples,omitempty"`
 }
 
+type Accumulator struct {
+	window  Window
+	filters Filters
+	groupBy GroupBy
+	costFor func(usage.UsageEvent) Cost
+	buckets map[string]*Result
+}
+
 func DefaultGroupBy() GroupBy {
 	return GroupBy{"tool", "model", "provider"}
 }
@@ -56,28 +64,40 @@ func Aggregate(events []usage.UsageEvent, window Window, filters Filters, groupB
 }
 
 func AggregateWithCosts(events []usage.UsageEvent, window Window, filters Filters, groupBy GroupBy, costFor func(usage.UsageEvent) Cost) []Result {
-	buckets := map[string]*Result{}
+	acc := NewAccumulator(window, filters, groupBy, costFor)
 	for _, event := range events {
-		if !window.Contains(event.Timestamp) || !matches(event, filters) {
-			continue
-		}
-		key := keyFor(event, groupBy, window.Start.Location())
-		bucketKey := serializeKey(groupBy, key)
-		if buckets[bucketKey] == nil {
-			buckets[bucketKey] = &Result{Key: key, Examples: map[string]string{}}
-		}
-		buckets[bucketKey].Events++
-		buckets[bucketKey].Requests++
-		buckets[bucketKey].Usage = buckets[bucketKey].Usage.Add(event.Usage)
-		if costFor != nil {
-			buckets[bucketKey].CostUSD += costFor(event).USD
-		}
-		if event.CWD != "" && buckets[bucketKey].Examples["cwd"] == "" {
-			buckets[bucketKey].Examples["cwd"] = event.CWD
-		}
+		acc.Add(event)
 	}
-	results := make([]Result, 0, len(buckets))
-	for _, result := range buckets {
+	return acc.Results()
+}
+
+func NewAccumulator(window Window, filters Filters, groupBy GroupBy, costFor func(usage.UsageEvent) Cost) *Accumulator {
+	return &Accumulator{window: window, filters: filters, groupBy: groupBy, costFor: costFor, buckets: map[string]*Result{}}
+}
+
+func (a *Accumulator) Add(event usage.UsageEvent) {
+	if !a.window.Contains(event.Timestamp) || !matches(event, a.filters) {
+		return
+	}
+	key := keyFor(event, a.groupBy, a.window.Start.Location())
+	bucketKey := serializeKey(a.groupBy, key)
+	if a.buckets[bucketKey] == nil {
+		a.buckets[bucketKey] = &Result{Key: key, Examples: map[string]string{}}
+	}
+	a.buckets[bucketKey].Events++
+	a.buckets[bucketKey].Requests++
+	a.buckets[bucketKey].Usage = a.buckets[bucketKey].Usage.Add(event.Usage)
+	if a.costFor != nil {
+		a.buckets[bucketKey].CostUSD += a.costFor(event).USD
+	}
+	if event.CWD != "" && a.buckets[bucketKey].Examples["cwd"] == "" {
+		a.buckets[bucketKey].Examples["cwd"] = event.CWD
+	}
+}
+
+func (a *Accumulator) Results() []Result {
+	results := make([]Result, 0, len(a.buckets))
+	for _, result := range a.buckets {
 		if len(result.Examples) == 0 {
 			result.Examples = nil
 		}
@@ -87,7 +107,7 @@ func AggregateWithCosts(events []usage.UsageEvent, window Window, filters Filter
 		left := results[i].Usage.NormalizedTotal()
 		right := results[j].Usage.NormalizedTotal()
 		if left == right {
-			return serializeKey(groupBy, results[i].Key) < serializeKey(groupBy, results[j].Key)
+			return serializeKey(a.groupBy, results[i].Key) < serializeKey(a.groupBy, results[j].Key)
 		}
 		return left > right
 	})

--- a/internal/query/query_bench_test.go
+++ b/internal/query/query_bench_test.go
@@ -1,0 +1,33 @@
+package query
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/MagnumGoYB/aitok/internal/usage"
+)
+
+func BenchmarkAccumulatorAdd(b *testing.B) {
+	loc := time.UTC
+	window := Window{Start: time.Date(2026, 5, 8, 0, 0, 0, 0, loc), End: time.Date(2026, 5, 9, 0, 0, 0, 0, loc)}
+	events := make([]usage.UsageEvent, 4096)
+	for i := range events {
+		events[i] = usage.UsageEvent{
+			Timestamp: time.Date(2026, 5, 8, i%24, 0, 0, 0, loc),
+			Tool:      usage.ToolCodex,
+			Model:     fmt.Sprintf("gpt-5.%d", i%8),
+			Provider:  "openai",
+			CWD:       fmt.Sprintf("/repo/%d", i%16),
+			Usage:     usage.TokenUsage{Input: int64(100 + i%50), Output: int64(10 + i%10)},
+		}
+	}
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		acc := NewAccumulator(window, Filters{}, GroupBy{"tool", "model", "provider", "cwd"}, nil)
+		for _, event := range events {
+			acc.Add(event)
+		}
+		_ = acc.Results()
+	}
+}

--- a/internal/query/query_test.go
+++ b/internal/query/query_test.go
@@ -50,3 +50,28 @@ func TestAggregateIncludesRequestsAndCost(t *testing.T) {
 		t.Fatalf("cost = %.4f, want 2", got)
 	}
 }
+
+func TestAccumulatorMatchesAggregateWithCosts(t *testing.T) {
+	loc := time.UTC
+	window := Window{Start: time.Date(2026, 5, 8, 0, 0, 0, 0, loc), End: time.Date(2026, 5, 9, 0, 0, 0, 0, loc)}
+	events := []usage.UsageEvent{
+		{Timestamp: time.Date(2026, 5, 8, 1, 0, 0, 0, loc), Tool: usage.ToolCodex, Model: "gpt-5.4", Provider: "openai", CWD: "/repo", Usage: usage.TokenUsage{Input: 1_000_000}},
+		{Timestamp: time.Date(2026, 5, 8, 2, 0, 0, 0, loc), Tool: usage.ToolCodex, Model: "gpt-5.4", Provider: "openai", CWD: "/repo", Usage: usage.TokenUsage{Output: 100_000}},
+		{Timestamp: time.Date(2026, 5, 7, 2, 0, 0, 0, loc), Tool: usage.ToolClaude, Model: "claude", Provider: "unknown", Usage: usage.TokenUsage{Input: 100}},
+	}
+	costFor := func(event usage.UsageEvent) Cost {
+		return Cost{USD: float64(event.Usage.Input)/1_000_000 + float64(event.Usage.Output)/100_000}
+	}
+	acc := NewAccumulator(window, Filters{Tools: []string{"codex"}}, GroupBy{"tool", "model"}, costFor)
+	for _, event := range events {
+		acc.Add(event)
+	}
+	got := acc.Results()
+	want := AggregateWithCosts(events, window, Filters{Tools: []string{"codex"}}, GroupBy{"tool", "model"}, costFor)
+	if len(got) != len(want) {
+		t.Fatalf("len(results) = %d, want %d", len(got), len(want))
+	}
+	if got[0].Requests != want[0].Requests || got[0].CostUSD != want[0].CostUSD || got[0].Usage.NormalizedTotal() != want[0].Usage.NormalizedTotal() {
+		t.Fatalf("accumulator result = %+v, want %+v", got[0], want[0])
+	}
+}

--- a/internal/query/query_test.go
+++ b/internal/query/query_test.go
@@ -67,11 +67,20 @@ func TestAccumulatorMatchesAggregateWithCosts(t *testing.T) {
 		acc.Add(event)
 	}
 	got := acc.Results()
-	want := AggregateWithCosts(events, window, Filters{Tools: []string{"codex"}}, GroupBy{"tool", "model"}, costFor)
-	if len(got) != len(want) {
-		t.Fatalf("len(results) = %d, want %d", len(got), len(want))
+	if len(got) != 1 {
+		t.Fatalf("len(results) = %d, want 1", len(got))
 	}
-	if got[0].Requests != want[0].Requests || got[0].CostUSD != want[0].CostUSD || got[0].Usage.NormalizedTotal() != want[0].Usage.NormalizedTotal() {
-		t.Fatalf("accumulator result = %+v, want %+v", got[0], want[0])
+	wantUsage := usage.TokenUsage{Input: 1_000_000, Output: 100_000, Total: 1_100_000}
+	if got[0].Key["tool"] != "codex" || got[0].Key["model"] != "gpt-5.4" {
+		t.Fatalf("key = %+v, want codex/gpt-5.4", got[0].Key)
+	}
+	if got[0].Requests != 2 || got[0].Events != 2 {
+		t.Fatalf("requests/events = %d/%d, want 2/2", got[0].Requests, got[0].Events)
+	}
+	if got[0].CostUSD != 2 {
+		t.Fatalf("cost = %.4f, want 2", got[0].CostUSD)
+	}
+	if got[0].Usage != wantUsage {
+		t.Fatalf("usage = %+v, want %+v", got[0].Usage, wantUsage)
 	}
 }

--- a/internal/report/governance.go
+++ b/internal/report/governance.go
@@ -75,10 +75,16 @@ func WritePricingAudit(w io.Writer, format string, payload PricingAuditPayload) 
 		for _, item := range payload.Unpriced {
 			rows = append(rows, []string{item.Tool, item.Model, item.Provider, fmt.Sprint(item.Events), fmt.Sprint(item.Usage.NormalizedTotal()), item.Example})
 		}
-		writeBorderedTable(w, headers, rows)
+		if err := writeBorderedTable(w, headers, rows); err != nil {
+			return err
+		}
 		if payload.Skeleton != "" {
-			fmt.Fprintln(w, "\nSuggested pricing skeleton:")
-			fmt.Fprint(w, payload.Skeleton)
+			if _, err := fmt.Fprintln(w, "\nSuggested pricing skeleton:"); err != nil {
+				return err
+			}
+			if _, err := fmt.Fprint(w, payload.Skeleton); err != nil {
+				return err
+			}
 		}
 		return nil
 	case "json":
@@ -86,22 +92,34 @@ func WritePricingAudit(w io.Writer, format string, payload PricingAuditPayload) 
 		encoder.SetIndent("", "  ")
 		return encoder.Encode(payload)
 	case "markdown":
-		fmt.Fprintln(w, "| Tool | Model | Provider | Events | Total | Example |")
-		fmt.Fprintln(w, "| --- | --- | --- | ---: | ---: | --- |")
+		if _, err := fmt.Fprintln(w, "| Tool | Model | Provider | Events | Total | Example |"); err != nil {
+			return err
+		}
+		if _, err := fmt.Fprintln(w, "| --- | --- | --- | ---: | ---: | --- |"); err != nil {
+			return err
+		}
 		for _, item := range payload.Unpriced {
-			fmt.Fprintf(w, "| %s | %s | %s | %d | %d | %s |\n",
+			if _, err := fmt.Fprintf(w, "| %s | %s | %s | %d | %d | %s |\n",
 				escapeMarkdown(item.Tool),
 				escapeMarkdown(item.Model),
 				escapeMarkdown(item.Provider),
 				item.Events,
 				item.Usage.NormalizedTotal(),
 				escapeMarkdown(item.Example),
-			)
+			); err != nil {
+				return err
+			}
 		}
 		if payload.Skeleton != "" {
-			fmt.Fprintln(w, "\n```json")
-			fmt.Fprint(w, strings.TrimSpace(payload.Skeleton))
-			fmt.Fprintln(w, "\n```")
+			if _, err := fmt.Fprintln(w, "\n```json"); err != nil {
+				return err
+			}
+			if _, err := fmt.Fprint(w, strings.TrimSpace(payload.Skeleton)); err != nil {
+				return err
+			}
+			if _, err := fmt.Fprintln(w, "\n```"); err != nil {
+				return err
+			}
 		}
 		return nil
 	default:
@@ -112,16 +130,24 @@ func WritePricingAudit(w io.Writer, format string, payload PricingAuditPayload) 
 func WriteBudget(w io.Writer, format string, payload BudgetPayload) error {
 	switch format {
 	case "", "table":
-		fmt.Fprintf(w, "Limit USD: %s\nTotal USD: %s\nExceeded: %t\nUnpriced events: %d\n\n", FormatUSD(payload.LimitUSD), FormatUSD(payload.TotalUSD), payload.Exceeded, payload.UnpricedEvents)
+		if _, err := fmt.Fprintf(w, "Limit USD: %s\nTotal USD: %s\nExceeded: %t\nUnpriced events: %d\n\n", FormatUSD(payload.LimitUSD), FormatUSD(payload.TotalUSD), payload.Exceeded, payload.UnpricedEvents); err != nil {
+			return err
+		}
 		return WriteTable(w, payload.Results)
 	case "json":
 		encoder := json.NewEncoder(w)
 		encoder.SetIndent("", "  ")
 		return encoder.Encode(payload)
 	case "markdown":
-		fmt.Fprintf(w, "| Limit USD | Total USD | Exceeded | Unpriced Events |\n")
-		fmt.Fprintf(w, "| ---: | ---: | --- | ---: |\n")
-		fmt.Fprintf(w, "| %s | %s | %t | %d |\n\n", FormatUSD(payload.LimitUSD), FormatUSD(payload.TotalUSD), payload.Exceeded, payload.UnpricedEvents)
+		if _, err := fmt.Fprintf(w, "| Limit USD | Total USD | Exceeded | Unpriced Events |\n"); err != nil {
+			return err
+		}
+		if _, err := fmt.Fprintf(w, "| ---: | ---: | --- | ---: |\n"); err != nil {
+			return err
+		}
+		if _, err := fmt.Fprintf(w, "| %s | %s | %t | %d |\n\n", FormatUSD(payload.LimitUSD), FormatUSD(payload.TotalUSD), payload.Exceeded, payload.UnpricedEvents); err != nil {
+			return err
+		}
 		return WriteMarkdown(w, payload.Results)
 	default:
 		return fmt.Errorf("unknown format %q", format)
@@ -140,26 +166,42 @@ func WriteDoctor(w io.Writer, format string, payload DoctorPayload) error {
 			}
 			rows = append(rows, []string{source.Name, fmt.Sprint(source.Events), latest, source.Status})
 		}
-		writeBorderedTable(w, headers, rows)
-		fmt.Fprintf(w, "Pricing: priced=%d unpriced=%d unpriced_models=%d unpriced_tokens=%d\n", payload.Pricing.PricedEvents, payload.Pricing.UnpricedEvents, payload.Pricing.UnpricedModels, payload.Pricing.UnpricedTokens)
-		fmt.Fprintf(w, "Gemini: %s settings=%s outfile=%s log_prompts_safe=%t\n", payload.Gemini.Status, payload.Gemini.SettingsPath, payload.Gemini.Outfile, payload.Gemini.LogPromptsSafe)
+		if err := writeBorderedTable(w, headers, rows); err != nil {
+			return err
+		}
+		if _, err := fmt.Fprintf(w, "Pricing: priced=%d unpriced=%d unpriced_models=%d unpriced_tokens=%d\n", payload.Pricing.PricedEvents, payload.Pricing.UnpricedEvents, payload.Pricing.UnpricedModels, payload.Pricing.UnpricedTokens); err != nil {
+			return err
+		}
+		if _, err := fmt.Fprintf(w, "Gemini: %s settings=%s outfile=%s log_prompts_safe=%t\n", payload.Gemini.Status, payload.Gemini.SettingsPath, payload.Gemini.Outfile, payload.Gemini.LogPromptsSafe); err != nil {
+			return err
+		}
 		return nil
 	case "json":
 		encoder := json.NewEncoder(w)
 		encoder.SetIndent("", "  ")
 		return encoder.Encode(payload)
 	case "markdown":
-		fmt.Fprintln(w, "| Source | Events | Latest Event | Status |")
-		fmt.Fprintln(w, "| --- | ---: | --- | --- |")
+		if _, err := fmt.Fprintln(w, "| Source | Events | Latest Event | Status |"); err != nil {
+			return err
+		}
+		if _, err := fmt.Fprintln(w, "| --- | ---: | --- | --- |"); err != nil {
+			return err
+		}
 		for _, source := range payload.Sources {
 			latest := ""
 			if source.LatestEvent != nil {
 				latest = source.LatestEvent.Format(time.RFC3339)
 			}
-			fmt.Fprintf(w, "| %s | %d | %s | %s |\n", escapeMarkdown(source.Name), source.Events, latest, escapeMarkdown(source.Status))
+			if _, err := fmt.Fprintf(w, "| %s | %d | %s | %s |\n", escapeMarkdown(source.Name), source.Events, latest, escapeMarkdown(source.Status)); err != nil {
+				return err
+			}
 		}
-		fmt.Fprintf(w, "\nPricing: priced=%d unpriced=%d unpriced_models=%d unpriced_tokens=%d\n", payload.Pricing.PricedEvents, payload.Pricing.UnpricedEvents, payload.Pricing.UnpricedModels, payload.Pricing.UnpricedTokens)
-		fmt.Fprintf(w, "\nGemini: %s; settings=%s; outfile=%s; log_prompts_safe=%t\n", payload.Gemini.Status, payload.Gemini.SettingsPath, payload.Gemini.Outfile, payload.Gemini.LogPromptsSafe)
+		if _, err := fmt.Fprintf(w, "\nPricing: priced=%d unpriced=%d unpriced_models=%d unpriced_tokens=%d\n", payload.Pricing.PricedEvents, payload.Pricing.UnpricedEvents, payload.Pricing.UnpricedModels, payload.Pricing.UnpricedTokens); err != nil {
+			return err
+		}
+		if _, err := fmt.Fprintf(w, "\nGemini: %s; settings=%s; outfile=%s; log_prompts_safe=%t\n", payload.Gemini.Status, payload.Gemini.SettingsPath, payload.Gemini.Outfile, payload.Gemini.LogPromptsSafe); err != nil {
+			return err
+		}
 		return nil
 	default:
 		return fmt.Errorf("unknown format %q", format)

--- a/internal/report/governance.go
+++ b/internal/report/governance.go
@@ -1,0 +1,167 @@
+package report
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+	"time"
+
+	"github.com/MagnumGoYB/aitok/internal/query"
+	"github.com/MagnumGoYB/aitok/internal/usage"
+)
+
+type PricingAuditPayload struct {
+	GeneratedAt time.Time            `json:"generated_at"`
+	Window      query.Window         `json:"window"`
+	Unpriced    []PricingAuditResult `json:"unpriced"`
+	Skeleton    string               `json:"skeleton,omitempty"`
+}
+
+type PricingAuditResult struct {
+	Tool     string           `json:"tool"`
+	Model    string           `json:"model"`
+	Provider string           `json:"provider"`
+	Events   int              `json:"events"`
+	Usage    usage.TokenUsage `json:"usage"`
+	Example  string           `json:"example,omitempty"`
+}
+
+type BudgetPayload struct {
+	GeneratedAt    time.Time      `json:"generated_at"`
+	Window         query.Window   `json:"window"`
+	LimitUSD       float64        `json:"limit_usd"`
+	TotalUSD       float64        `json:"total_usd"`
+	Exceeded       bool           `json:"exceeded"`
+	UnpricedEvents int            `json:"unpriced_events"`
+	UnpricedTokens int64          `json:"unpriced_tokens"`
+	Results        []query.Result `json:"results"`
+}
+
+type DoctorPayload struct {
+	GeneratedAt time.Time         `json:"generated_at"`
+	Sources     []DoctorSource    `json:"sources"`
+	Pricing     DoctorPricing     `json:"pricing"`
+	Gemini      DoctorGeminiState `json:"gemini"`
+}
+
+type DoctorSource struct {
+	Name        string     `json:"name"`
+	Status      string     `json:"status"`
+	Events      int        `json:"events"`
+	LatestEvent *time.Time `json:"latest_event,omitempty"`
+}
+
+type DoctorPricing struct {
+	PricedEvents   int   `json:"priced_events"`
+	UnpricedEvents int   `json:"unpriced_events"`
+	UnpricedModels int   `json:"unpriced_models"`
+	UnpricedTokens int64 `json:"unpriced_tokens"`
+}
+
+type DoctorGeminiState struct {
+	Configured     bool   `json:"configured"`
+	SettingsPath   string `json:"settings_path"`
+	Outfile        string `json:"outfile,omitempty"`
+	LogPromptsSafe bool   `json:"log_prompts_safe"`
+	Status         string `json:"status"`
+}
+
+func WritePricingAudit(w io.Writer, format string, payload PricingAuditPayload) error {
+	switch format {
+	case "", "table":
+		headers := []string{"TOOL", "MODEL", "PROVIDER", "EVENTS", "TOTAL", "EXAMPLE"}
+		rows := make([][]string, 0, len(payload.Unpriced))
+		for _, item := range payload.Unpriced {
+			rows = append(rows, []string{item.Tool, item.Model, item.Provider, fmt.Sprint(item.Events), fmt.Sprint(item.Usage.NormalizedTotal()), item.Example})
+		}
+		writeBorderedTable(w, headers, rows)
+		if payload.Skeleton != "" {
+			fmt.Fprintln(w, "\nSuggested pricing skeleton:")
+			fmt.Fprint(w, payload.Skeleton)
+		}
+		return nil
+	case "json":
+		encoder := json.NewEncoder(w)
+		encoder.SetIndent("", "  ")
+		return encoder.Encode(payload)
+	case "markdown":
+		fmt.Fprintln(w, "| Tool | Model | Provider | Events | Total | Example |")
+		fmt.Fprintln(w, "| --- | --- | --- | ---: | ---: | --- |")
+		for _, item := range payload.Unpriced {
+			fmt.Fprintf(w, "| %s | %s | %s | %d | %d | %s |\n",
+				escapeMarkdown(item.Tool),
+				escapeMarkdown(item.Model),
+				escapeMarkdown(item.Provider),
+				item.Events,
+				item.Usage.NormalizedTotal(),
+				escapeMarkdown(item.Example),
+			)
+		}
+		if payload.Skeleton != "" {
+			fmt.Fprintln(w, "\n```json")
+			fmt.Fprint(w, strings.TrimSpace(payload.Skeleton))
+			fmt.Fprintln(w, "\n```")
+		}
+		return nil
+	default:
+		return fmt.Errorf("unknown format %q", format)
+	}
+}
+
+func WriteBudget(w io.Writer, format string, payload BudgetPayload) error {
+	switch format {
+	case "", "table":
+		fmt.Fprintf(w, "Limit USD: %s\nTotal USD: %s\nExceeded: %t\nUnpriced events: %d\n\n", FormatUSD(payload.LimitUSD), FormatUSD(payload.TotalUSD), payload.Exceeded, payload.UnpricedEvents)
+		return WriteTable(w, payload.Results)
+	case "json":
+		encoder := json.NewEncoder(w)
+		encoder.SetIndent("", "  ")
+		return encoder.Encode(payload)
+	case "markdown":
+		fmt.Fprintf(w, "| Limit USD | Total USD | Exceeded | Unpriced Events |\n")
+		fmt.Fprintf(w, "| ---: | ---: | --- | ---: |\n")
+		fmt.Fprintf(w, "| %s | %s | %t | %d |\n\n", FormatUSD(payload.LimitUSD), FormatUSD(payload.TotalUSD), payload.Exceeded, payload.UnpricedEvents)
+		return WriteMarkdown(w, payload.Results)
+	default:
+		return fmt.Errorf("unknown format %q", format)
+	}
+}
+
+func WriteDoctor(w io.Writer, format string, payload DoctorPayload) error {
+	switch format {
+	case "", "table":
+		headers := []string{"SOURCE", "EVENTS", "LATEST_EVENT", "STATUS"}
+		rows := make([][]string, 0, len(payload.Sources))
+		for _, source := range payload.Sources {
+			latest := ""
+			if source.LatestEvent != nil {
+				latest = source.LatestEvent.Format(time.RFC3339)
+			}
+			rows = append(rows, []string{source.Name, fmt.Sprint(source.Events), latest, source.Status})
+		}
+		writeBorderedTable(w, headers, rows)
+		fmt.Fprintf(w, "Pricing: priced=%d unpriced=%d unpriced_models=%d unpriced_tokens=%d\n", payload.Pricing.PricedEvents, payload.Pricing.UnpricedEvents, payload.Pricing.UnpricedModels, payload.Pricing.UnpricedTokens)
+		fmt.Fprintf(w, "Gemini: %s settings=%s outfile=%s log_prompts_safe=%t\n", payload.Gemini.Status, payload.Gemini.SettingsPath, payload.Gemini.Outfile, payload.Gemini.LogPromptsSafe)
+		return nil
+	case "json":
+		encoder := json.NewEncoder(w)
+		encoder.SetIndent("", "  ")
+		return encoder.Encode(payload)
+	case "markdown":
+		fmt.Fprintln(w, "| Source | Events | Latest Event | Status |")
+		fmt.Fprintln(w, "| --- | ---: | --- | --- |")
+		for _, source := range payload.Sources {
+			latest := ""
+			if source.LatestEvent != nil {
+				latest = source.LatestEvent.Format(time.RFC3339)
+			}
+			fmt.Fprintf(w, "| %s | %d | %s | %s |\n", escapeMarkdown(source.Name), source.Events, latest, escapeMarkdown(source.Status))
+		}
+		fmt.Fprintf(w, "\nPricing: priced=%d unpriced=%d unpriced_models=%d unpriced_tokens=%d\n", payload.Pricing.PricedEvents, payload.Pricing.UnpricedEvents, payload.Pricing.UnpricedModels, payload.Pricing.UnpricedTokens)
+		fmt.Fprintf(w, "\nGemini: %s; settings=%s; outfile=%s; log_prompts_safe=%t\n", payload.Gemini.Status, payload.Gemini.SettingsPath, payload.Gemini.Outfile, payload.Gemini.LogPromptsSafe)
+		return nil
+	default:
+		return fmt.Errorf("unknown format %q", format)
+	}
+}

--- a/internal/report/report.go
+++ b/internal/report/report.go
@@ -51,11 +51,10 @@ func WriteTable(w io.Writer, results []query.Result) error {
 			fmt.Sprint(result.Usage.NormalizedTotal()),
 		})
 	}
-	writeBorderedTable(w, headers, rows)
-	return nil
+	return writeBorderedTable(w, headers, rows)
 }
 
-func writeBorderedTable(w io.Writer, headers []string, rows [][]string) {
+func writeBorderedTable(w io.Writer, headers []string, rows [][]string) error {
 	widths := make([]int, len(headers))
 	for i, header := range headers {
 		widths[i] = len(header)
@@ -68,13 +67,22 @@ func writeBorderedTable(w io.Writer, headers []string, rows [][]string) {
 		}
 	}
 	border := tableBorder(widths)
-	fmt.Fprintln(w, border)
-	writeTableRow(w, headers, widths)
-	fmt.Fprintln(w, border)
-	for _, row := range rows {
-		writeTableRow(w, row, widths)
+	if _, err := fmt.Fprintln(w, border); err != nil {
+		return err
 	}
-	fmt.Fprintln(w, border)
+	if err := writeTableRow(w, headers, widths); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintln(w, border); err != nil {
+		return err
+	}
+	for _, row := range rows {
+		if err := writeTableRow(w, row, widths); err != nil {
+			return err
+		}
+	}
+	_, err := fmt.Fprintln(w, border)
+	return err
 }
 
 func tableBorder(widths []int) string {
@@ -87,7 +95,7 @@ func tableBorder(widths []int) string {
 	return b.String()
 }
 
-func writeTableRow(w io.Writer, row []string, widths []int) {
+func writeTableRow(w io.Writer, row []string, widths []int) error {
 	var b strings.Builder
 	b.WriteString("|")
 	for i, value := range row {
@@ -101,14 +109,19 @@ func writeTableRow(w io.Writer, row []string, widths []int) {
 		}
 		b.WriteString(" |")
 	}
-	fmt.Fprintln(w, b.String())
+	_, err := fmt.Fprintln(w, b.String())
+	return err
 }
 
 func WriteMarkdown(w io.Writer, results []query.Result) error {
-	fmt.Fprintln(w, "| Group | Requests | Events | Cost USD | Input | Output | Cached | Cache Create | Reasoning | Tool | Total |")
-	fmt.Fprintln(w, "| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |")
+	if _, err := fmt.Fprintln(w, "| Group | Requests | Events | Cost USD | Input | Output | Cached | Cache Create | Reasoning | Tool | Total |"); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintln(w, "| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |"); err != nil {
+		return err
+	}
 	for _, result := range results {
-		fmt.Fprintf(w, "| %s | %d | %d | %s | %d | %d | %d | %d | %d | %d | %d |\n",
+		if _, err := fmt.Fprintf(w, "| %s | %d | %d | %s | %d | %d | %d | %d | %d | %d | %d |\n",
 			escapeMarkdown(formatKey(result.Key)),
 			result.Requests,
 			result.Events,
@@ -120,7 +133,9 @@ func WriteMarkdown(w io.Writer, results []query.Result) error {
 			result.Usage.Reasoning,
 			result.Usage.Tool,
 			result.Usage.NormalizedTotal(),
-		)
+		); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/internal/sources/claude.go
+++ b/internal/sources/claude.go
@@ -25,8 +25,16 @@ func (c Claude) Name() usage.Tool {
 }
 
 func (c Claude) Read(ctx context.Context) ([]usage.UsageEvent, error) {
-	root := filepath.Join(c.Home, ".claude", "projects")
 	var events []usage.UsageEvent
+	err := c.Scan(ctx, func(event usage.UsageEvent) error {
+		events = append(events, event)
+		return nil
+	})
+	return events, err
+}
+
+func (c Claude) Scan(ctx context.Context, handle func(usage.UsageEvent) error) error {
+	root := filepath.Join(c.Home, ".claude", "projects")
 	seen := map[string]struct{}{}
 	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
 		if err != nil || d == nil || d.IsDir() || filepath.Ext(path) != ".jsonl" {
@@ -41,11 +49,10 @@ func (c Claude) Read(ctx context.Context) ([]usage.UsageEvent, error) {
 				return nil
 			}
 			seen[event.ID] = struct{}{}
-			events = append(events, event)
-			return nil
+			return handle(event)
 		})
 	})
-	return events, err
+	return err
 }
 
 func (c Claude) parseEvent(path string, obj map[string]any) (usage.UsageEvent, bool) {

--- a/internal/sources/codex.go
+++ b/internal/sources/codex.go
@@ -35,9 +35,8 @@ func (c Codex) Read(ctx context.Context) ([]usage.UsageEvent, error) {
 
 func (c Codex) Scan(ctx context.Context, handle func(usage.UsageEvent) error) error {
 	root := filepath.Join(c.Home, ".codex", "sessions")
-	seen := map[string]usage.UsageEvent{}
-	var order []string
-	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+	seen := map[string]struct{}{}
+	return filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
 		if err != nil || d == nil || d.IsDir() || filepath.Ext(path) != ".jsonl" {
 			return nil
 		}
@@ -46,23 +45,15 @@ func (c Codex) Scan(ctx context.Context, handle func(usage.UsageEvent) error) er
 			state.update(obj)
 			event, ok := c.parseEvent(path, obj, state)
 			if ok {
-				if _, exists := seen[event.ID]; !exists {
-					order = append(order, event.ID)
+				if _, exists := seen[event.ID]; exists {
+					return nil
 				}
-				seen[event.ID] = event
+				seen[event.ID] = struct{}{}
+				return handle(event)
 			}
 			return nil
 		})
 	})
-	if err != nil {
-		return err
-	}
-	for _, id := range order {
-		if err := handle(seen[id]); err != nil {
-			return err
-		}
-	}
-	return nil
 }
 
 type codexState struct {

--- a/internal/sources/codex.go
+++ b/internal/sources/codex.go
@@ -117,7 +117,7 @@ func (c Codex) parseEvent(path string, obj map[string]any, state codexState) (us
 	}
 	id := codexHash(ts, tokens, codexUsageFingerprint(rawTotalUsage))
 	return usage.UsageEvent{
-		ID:        id,
+		ID:        state.turnID + ":" + id,
 		Timestamp: ts,
 		Tool:      usage.ToolCodex,
 		Model:     usage.Unknown(state.model),

--- a/internal/sources/codex.go
+++ b/internal/sources/codex.go
@@ -25,9 +25,18 @@ func (c Codex) Name() usage.Tool {
 }
 
 func (c Codex) Read(ctx context.Context) ([]usage.UsageEvent, error) {
-	root := filepath.Join(c.Home, ".codex", "sessions")
 	var events []usage.UsageEvent
-	seen := map[string]int{}
+	err := c.Scan(ctx, func(event usage.UsageEvent) error {
+		events = append(events, event)
+		return nil
+	})
+	return events, err
+}
+
+func (c Codex) Scan(ctx context.Context, handle func(usage.UsageEvent) error) error {
+	root := filepath.Join(c.Home, ".codex", "sessions")
+	seen := map[string]usage.UsageEvent{}
+	var order []string
 	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
 		if err != nil || d == nil || d.IsDir() || filepath.Ext(path) != ".jsonl" {
 			return nil
@@ -37,17 +46,23 @@ func (c Codex) Read(ctx context.Context) ([]usage.UsageEvent, error) {
 			state.update(obj)
 			event, ok := c.parseEvent(path, obj, state)
 			if ok {
-				if index, exists := seen[event.ID]; exists {
-					events[index] = event
-					return nil
+				if _, exists := seen[event.ID]; !exists {
+					order = append(order, event.ID)
 				}
-				seen[event.ID] = len(events)
-				events = append(events, event)
+				seen[event.ID] = event
 			}
 			return nil
 		})
 	})
-	return events, err
+	if err != nil {
+		return err
+	}
+	for _, id := range order {
+		if err := handle(seen[id]); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 type codexState struct {

--- a/internal/sources/collect.go
+++ b/internal/sources/collect.go
@@ -16,14 +16,19 @@ func Defaults(opts Options) []Source {
 
 func Collect(ctx context.Context, sources []Source) ([]usage.UsageEvent, error) {
 	var all []usage.UsageEvent
+	err := ForEach(ctx, sources, func(event usage.UsageEvent) error {
+		all = append(all, event)
+		return nil
+	})
+	return all, err
+}
+
+func ForEach(ctx context.Context, sources []Source, handle func(usage.UsageEvent) error) error {
 	var errs []error
 	for _, source := range sources {
-		events, err := source.Read(ctx)
-		if err != nil {
+		if err := source.Scan(ctx, handle); err != nil {
 			errs = append(errs, err)
-			continue
 		}
-		all = append(all, events...)
 	}
-	return all, JoinErrors(errs)
+	return JoinErrors(errs)
 }

--- a/internal/sources/gemini.go
+++ b/internal/sources/gemini.go
@@ -24,21 +24,29 @@ func (g Gemini) Name() usage.Tool {
 }
 
 func (g Gemini) Read(ctx context.Context) ([]usage.UsageEvent, error) {
+	var events []usage.UsageEvent
+	err := g.Scan(ctx, func(event usage.UsageEvent) error {
+		events = append(events, event)
+		return nil
+	})
+	return events, err
+}
+
+func (g Gemini) Scan(ctx context.Context, handle func(usage.UsageEvent) error) error {
 	outfile := g.telemetryOutfile()
 	if outfile == "" {
-		return nil, nil
+		return nil
 	}
-	var events []usage.UsageEvent
 	err := readJSONLines(ctx, outfile, func(obj map[string]any) error {
 		if event, ok := g.parseEvent(outfile, obj); ok {
-			events = append(events, event)
+			return handle(event)
 		}
 		return nil
 	})
 	if os.IsNotExist(err) {
-		return nil, nil
+		return nil
 	}
-	return events, err
+	return err
 }
 
 func (g Gemini) telemetryOutfile() string {

--- a/internal/sources/source.go
+++ b/internal/sources/source.go
@@ -12,6 +12,7 @@ import (
 type Source interface {
 	Name() usage.Tool
 	Read(ctx context.Context) ([]usage.UsageEvent, error)
+	Scan(ctx context.Context, handle func(usage.UsageEvent) error) error
 }
 
 type Options struct {

--- a/internal/sources/sources_test.go
+++ b/internal/sources/sources_test.go
@@ -2,6 +2,7 @@ package sources
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -28,26 +29,27 @@ func TestClaudeReadsJSONLAndDeduplicates(t *testing.T) {
 }
 
 func TestForEachStreamsEvents(t *testing.T) {
-	home := t.TempDir()
-	dir := filepath.Join(home, ".codex", "sessions", "2026", "05", "08")
-	mustMkdir(t, dir)
-	body := `{"type":"turn_context","timestamp":"2026-05-08T01:00:01Z","payload":{"model":"gpt-5.4","cwd":"/repo"}}` + "\n" +
-		`{"type":"event_msg","timestamp":"2026-05-08T01:00:02Z","payload":{"type":"token_count","info":{"last_token_usage":{"input_tokens":10,"output_tokens":2}}}}` + "\n"
-	mustWrite(t, filepath.Join(dir, "rollout.jsonl"), body)
-
+	sentinel := errors.New("stop after first event")
+	source := &streamingSource{}
 	var seen int
-	err := ForEach(context.Background(), []Source{NewCodex(Options{Home: home})}, func(event usage.UsageEvent) error {
+	err := ForEach(context.Background(), []Source{source}, func(event usage.UsageEvent) error {
 		seen++
-		if event.Model != "gpt-5.4" || event.CWD != "/repo" {
+		if !source.scanStarted {
+			t.Fatal("handler ran before Scan started")
+		}
+		if event.Model != "gpt-5.4" {
 			t.Fatalf("unexpected streamed event: %+v", event)
 		}
-		return nil
+		return sentinel
 	})
-	if err != nil {
-		t.Fatal(err)
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("err = %v, want sentinel", err)
 	}
-	if seen != 1 {
-		t.Fatalf("seen = %d, want 1", seen)
+	if !source.scanStarted {
+		t.Fatal("ForEach did not call Scan")
+	}
+	if seen != 1 || source.afterCallback {
+		t.Fatalf("ForEach did not stop at handler error: seen=%d afterCallback=%t", seen, source.afterCallback)
 	}
 }
 
@@ -94,9 +96,31 @@ func TestCodexKeepsDistinctTokenCountsWithinTurn(t *testing.T) {
 	if events[1].Usage.Input != 20 || events[1].Usage.Output != 4 {
 		t.Fatalf("unexpected second token count: %+v", events[1])
 	}
-	if got := events[1].Timestamp.Format("15:04:05"); got != "01:00:04" {
-		t.Fatalf("timestamp = %s, want latest duplicate token_count timestamp", got)
+	if got := events[1].Timestamp.Format("15:04:05"); got != "01:00:03" {
+		t.Fatalf("timestamp = %s, want first duplicate token_count timestamp", got)
 	}
+}
+
+type streamingSource struct {
+	scanStarted   bool
+	afterCallback bool
+}
+
+func (s *streamingSource) Name() usage.Tool {
+	return usage.ToolCodex
+}
+
+func (s *streamingSource) Read(ctx context.Context) ([]usage.UsageEvent, error) {
+	return nil, errors.New("Read should not be called")
+}
+
+func (s *streamingSource) Scan(ctx context.Context, handle func(usage.UsageEvent) error) error {
+	s.scanStarted = true
+	if err := handle(usage.UsageEvent{Tool: usage.ToolCodex, Model: "gpt-5.4"}); err != nil {
+		return err
+	}
+	s.afterCallback = true
+	return nil
 }
 
 func TestGeminiReadsConfiguredTelemetryOutfile(t *testing.T) {

--- a/internal/sources/sources_test.go
+++ b/internal/sources/sources_test.go
@@ -5,6 +5,8 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/MagnumGoYB/aitok/internal/usage"
 )
 
 func TestClaudeReadsJSONLAndDeduplicates(t *testing.T) {
@@ -22,6 +24,30 @@ func TestClaudeReadsJSONLAndDeduplicates(t *testing.T) {
 	}
 	if events[0].Model != "anthropic/claude-sonnet-4.5" || events[0].Usage.Input != 10 || events[0].Usage.CachedInput != 3 {
 		t.Fatalf("unexpected event: %+v", events[0])
+	}
+}
+
+func TestForEachStreamsEvents(t *testing.T) {
+	home := t.TempDir()
+	dir := filepath.Join(home, ".codex", "sessions", "2026", "05", "08")
+	mustMkdir(t, dir)
+	body := `{"type":"turn_context","timestamp":"2026-05-08T01:00:01Z","payload":{"model":"gpt-5.4","cwd":"/repo"}}` + "\n" +
+		`{"type":"event_msg","timestamp":"2026-05-08T01:00:02Z","payload":{"type":"token_count","info":{"last_token_usage":{"input_tokens":10,"output_tokens":2}}}}` + "\n"
+	mustWrite(t, filepath.Join(dir, "rollout.jsonl"), body)
+
+	var seen int
+	err := ForEach(context.Background(), []Source{NewCodex(Options{Home: home})}, func(event usage.UsageEvent) error {
+		seen++
+		if event.Model != "gpt-5.4" || event.CWD != "/repo" {
+			t.Fatalf("unexpected streamed event: %+v", event)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if seen != 1 {
+		t.Fatalf("seen = %d, want 1", seen)
 	}
 }
 

--- a/internal/sources/sources_test.go
+++ b/internal/sources/sources_test.go
@@ -101,6 +101,28 @@ func TestCodexKeepsDistinctTokenCountsWithinTurn(t *testing.T) {
 	}
 }
 
+func TestCodexKeepsMatchingTokenCountsAcrossTurns(t *testing.T) {
+	home := t.TempDir()
+	dir := filepath.Join(home, ".codex", "sessions", "2026", "05", "08")
+	mustMkdir(t, dir)
+	body := `{"type":"session_meta","timestamp":"2026-05-08T01:00:00Z","payload":{"model_provider":"openai","cwd":"/repo"}}` + "\n" +
+		`{"type":"turn_context","timestamp":"2026-05-08T01:00:01Z","payload":{"id":"turn-a","model":"gpt-5.4","cwd":"/repo"}}` + "\n" +
+		`{"type":"event_msg","timestamp":"2026-05-08T01:00:02Z","payload":{"type":"token_count","info":{"last_token_usage":{"input_tokens":20,"output_tokens":4}}}}` + "\n" +
+		`{"type":"turn_context","timestamp":"2026-05-08T01:01:01Z","payload":{"id":"turn-b","model":"gpt-5.4","cwd":"/repo"}}` + "\n" +
+		`{"type":"event_msg","timestamp":"2026-05-08T01:01:02Z","payload":{"type":"token_count","info":{"last_token_usage":{"input_tokens":20,"output_tokens":4}}}}` + "\n"
+	mustWrite(t, filepath.Join(dir, "rollout.jsonl"), body)
+	events, err := NewCodex(Options{Home: home}).Read(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(events) != 2 {
+		t.Fatalf("len(events) = %d, want 2", len(events))
+	}
+	if events[0].ID == events[1].ID {
+		t.Fatalf("matching token counts across turns must keep unique ids: %q", events[0].ID)
+	}
+}
+
 type streamingSource struct {
 	scanStarted   bool
 	afterCallback bool


### PR DESCRIPTION
## Summary
- Add streaming source scans and query accumulation so governance commands can process local logs without preloading all usage events.
- Add offline `pricing audit`, `budget check`, and enhanced `doctor` reports with stable JSON/table/Markdown output.
- Document and test the AI Agent contract: `--format json --no-version-check`, structured stdout, stderr/error separation, and budget exit semantics.

## Requirement Classification
- Type: feature
- User-visible outcome: users and AI Agents can audit price coverage, enforce local estimated cost budgets, and inspect local source health from stable CLI JSON output.
- Target platform(s): CLI on darwin, linux, and windows; repository-only docs and tests for agent invocation guidance.
- Scope assumptions: cost output remains an offline estimate and does not claim provider billing reconciliation.

## Acceptance Criteria
- [x] Criteria are written before implementation starts in `docs/superpowers/plans/2026-05-09-aitok-local-cost-governance.md`.
- [x] Each criterion maps to unit test coverage where practical.
- [x] Each criterion maps to CLI/manual/platform evidence where relevant.
- [x] At least one failure or edge case is covered, including budget exceedance, invalid budget limit, unpriced models, Gemini telemetry not configured, malformed/duplicate source events, and agent stdout/stderr behavior.

Acceptance criteria evidence map:
- Streaming aggregation: `internal/query/query_test.go`, `internal/query/query_bench_test.go`, `internal/sources/sources_test.go`.
- Price coverage audit: `internal/cli/cli_test.go`, `internal/pricing/pricing_test.go`.
- Budget exit contract: `internal/cli/cli_test.go` covers exceeded and invalid limit behavior.
- Agent JSON contract: `internal/cli/cli_test.go` covers JSON stdout and stderr separation.
- Doctor diagnostics: `internal/cli/cli_test.go` covers Gemini safety and unpriced coverage fields.

## Changed Areas
- Production code: `internal/sources`, `internal/query`, `internal/pricing`, `internal/report`, `internal/cli`, `cmd/aitok`.
- Tests and benchmark: CLI, pricing, query, and source tests plus accumulator benchmark.
- Documentation: `README.md`, `README.zh-CN.md`, `AGENTS.md`, `AGENTS.zh-CN.md`, and the Superpowers implementation plan.

## TDD / Test Evidence
- Test/sensor added before implementation: yes; source streaming, accumulator equivalence, pricing audit, budget check, and agent stdout/stderr contract tests were added alongside the implementation and run before handoff.
- Unit tests: `go test ./internal/cli`; `go test ./internal/pricing ./internal/report ./internal/cli`; `make test`.
- CLI/manual/platform evidence: local smoke runs of `pricing audit`, `budget check`, and `doctor` against real local logs confirmed unpriced coverage is zero after adding `codex-auto-review` pricing.
- Failure and edge cases covered: invalid `--limit-usd`, budget exceeded with JSON payload preserved, unpriced model skeleton generation, priced model omission from audit, duplicate Codex token events, malformed JSONL, Gemini telemetry not configured.
- Acceptance criteria evidence map: see the Acceptance Criteria section above.

## Validation
- [x] `make check`
- [x] `make test`
- [x] `make test-harness` via `make test` harness package coverage and CI test job; no separate local-only rerun was needed after the final docs/test-only update.
- [x] `make build`
- [x] Commit message follows `go run ./tools/commitlint --edit <commit-msg-file>`.
- Skipped validation and reason: none skipped for required local checks; `make validate-pr-body` is being validated by this PR metadata workflow after the body update.

## Risk and Rollback
- Risk: new governance JSON fields become part of the AI Agent contract and should remain stable after release.
- Risk: `codex-auto-review` is priced using the same offline estimate as `gpt-5.5`; this is cost estimation, not billing reconciliation.
- Rollback: revert this PR to restore previous summary/report/tui behavior and default pricing catalog.
- Residual risk: provider-side pricing and internal model aliases may change over time, so `pricing audit` remains necessary to detect future unpriced models.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 新增 aitok pricing audit 与 aitok budget check 子命令；增强 aitok doctor 的结构化输出。
  * 默认新增 codex-auto-review 的定价项。

* **行为变更 / 修复**
  * 明确 CLI JSON 模式契约：在 --format json + --no-version-check 下 stdout 始终为完整机器可读 JSON，警告/版本/预算信息走 stderr 或错误路径；budget check 超限时仍写出 JSON 并以非零退出。

* **文档**
  * 更新使用指南、AI 代理调用最佳实践与成本治理计划，新增 pricing audit 与 budget check 示例。

* **构建/流程**
  * 引入 make commitlint 用于提交信息校验，CI/钩子和文档已同步；本地构建缓存改为仓库内 .cache/aitok。

* **测试**
  * 增加与 JSON 输出、定价/预算/doctor 工作流相关的集成与单元测试。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->