### PR TITLE
[codex] Add TUI threads list and period display fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ go install ./cmd/aitok
 
 ```bash
 aitok summary --period today
+aitok summary --period today --threads --format json
 aitok summary --period this-week --group-by tool,model,provider --format markdown
 aitok report --period last-week --format json
 aitok tui
@@ -56,6 +57,7 @@ AI agents and scripts should prefer JSON output and skip the low-frequency versi
 
 ```bash
 aitok --no-version-check summary --period today --format json
+aitok --no-version-check summary --period today --threads --format json
 aitok --no-version-check pricing audit --period this-month --format json
 aitok --no-version-check doctor --format json
 aitok --no-version-check budget check --period this-month --limit-usd 20 --format json
@@ -63,7 +65,7 @@ aitok --no-version-check budget check --period this-month --limit-usd 20 --forma
 
 For JSON commands, stdout is reserved for the structured payload. Warnings, version prompts, and budget failure summaries are written to stderr or returned through the process exit status. `budget check` exits with status `1` when the limit is exceeded but still writes the full JSON payload to stdout for parsing.
 
-The TUI uses English by default. Pass `--lang zh-CN` to start in Chinese, or press `l` inside the TUI to switch languages.
+The TUI uses English by default. Pass `--lang zh-CN` to start in Chinese, or press `l` inside the TUI to switch languages. When threads are present, press `t` to focus the Threads box, `j/k` or arrow keys to move the selected row, `home/end` to jump, and `c` to copy the selected thread ID through OSC52.
 
 `aitok update` checks the latest GitHub Release immediately and runs the matching local upgrade command when the install method supports it. Homebrew installs use `brew update && brew upgrade --cask aitok`; Go installs use `go install github.com/MagnumGoYB/aitok/cmd/aitok@latest`. Direct release binaries print the download URL.
 
@@ -89,6 +91,14 @@ Grouping:
 ```
 
 Reports include request count, token totals, cache tokens, and estimated USD cost. Cost uses an offline default model price catalog based on an official public pricing snapshot and can be overridden locally:
+
+To include matching local sessions in the summary payload, pass `--threads`:
+
+```bash
+aitok summary --period today --threads --format json
+```
+
+Thread rows include ID, name, tool, model, provider, token usage, requests, events, source, and estimated USD cost. The title comes from local logs only, preferring custom title, AI summary title, first real user message, cwd basename, then short ID.
 
 ```json
 {

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -37,6 +37,7 @@ go install ./cmd/aitok
 
 ```bash
 aitok summary --period today
+aitok summary --period today --threads --format json
 aitok summary --period this-week --group-by tool,model,provider --format markdown
 aitok report --period last-week --format json
 aitok tui
@@ -56,6 +57,7 @@ AI Agent 和脚本应优先使用 JSON 输出，并跳过低频版本检查：
 
 ```bash
 aitok --no-version-check summary --period today --format json
+aitok --no-version-check summary --period today --threads --format json
 aitok --no-version-check pricing audit --period this-month --format json
 aitok --no-version-check doctor --format json
 aitok --no-version-check budget check --period this-month --limit-usd 20 --format json
@@ -63,7 +65,7 @@ aitok --no-version-check budget check --period this-month --limit-usd 20 --forma
 
 对于 JSON 命令，stdout 只承载结构化 payload。warning、版本提示和预算失败摘要写入 stderr，或通过进程退出状态表达。`budget check` 超过限制时返回状态码 `1`，但仍会把完整 JSON payload 写入 stdout，便于 Agent 解析。
 
-TUI 默认使用英文文案。传入 `--lang zh-CN` 可默认显示中文，也可以在 TUI 中按 `l` 切换语言。
+TUI 默认使用英文文案。传入 `--lang zh-CN` 可默认显示中文，也可以在 TUI 中按 `l` 切换语言。当存在 threads 时，按 `t` 聚焦 Threads 窗口，使用 `j/k` 或方向键移动选中行，`home/end` 跳转首尾，`c` 通过 OSC52 复制选中的 thread ID。
 
 `aitok update` 会立即检查最新 GitHub Release，并在当前安装方式支持时执行对应的本地升级命令。Homebrew 安装会使用 `brew update && brew upgrade --cask aitok`；Go 安装会使用 `go install github.com/MagnumGoYB/aitok/cmd/aitok@latest`。直接下载的 release 二进制会打印下载地址。
 
@@ -88,7 +90,15 @@ TUI 默认使用英文文案。传入 `--lang zh-CN` 可默认显示中文，也
 --group-by tool,model,provider,day,cwd
 ```
 
-报告会返回请求数量、Token 总量、缓存 Token 和预估 USD 成本。成本默认使用基于官方公开价格快照的离线 model 价格表，也支持本地覆盖：
+报告会返回请求数量、Token 总量、缓存 Token 和预估 USD 成本。若需要在 summary payload 中包含匹配的本机会话列表，传入 `--threads`：
+
+```bash
+aitok summary --period today --threads --format json
+```
+
+Thread 行包含 ID、名称、tool、model、provider、Token 用量、requests、events、source 和预估 USD 成本。标题只读取本地日志，优先级为 custom title、AI 总结标题、首条真实用户消息、cwd basename、short ID。
+
+成本默认使用基于官方公开价格快照的离线 model 价格表，也支持本地覆盖：
 
 ```json
 {

--- a/docs/superpowers/plans/2026-05-11-tui-period-threads-list.md
+++ b/docs/superpowers/plans/2026-05-11-tui-period-threads-list.md
@@ -1,0 +1,50 @@
+# aitok 日期展示与 Threads 交互计划
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 修正 TUI 日期展示，并新增可交互 threads 窗口与 `summary --threads` 机器输出。
+
+**Architecture:** 在 source 解析阶段补充会话元信息，在 query 层按 thread 聚合，report/CLI 只在显式开启 `--threads` 时输出 threads。TUI 复用同一 payload 渲染固定表头、焦点驱动滚动条和 OSC52 复制 ID，不改变现有 period 查询语义。
+
+**Tech Stack:** Go 1.26.3+、Cobra CLI、Bubble Tea、Lip Gloss、标准库 JSON/文件扫描。
+
+---
+
+## Summary
+
+本次按 feature + bugfix 处理：修正 TUI 日期展示，并新增可交互 threads 窗口。参考 `cc-switch` 的会话发现方式，标题优先级固定为：custom title > AI 总结标题字段或尾部标题事件 > 首条真实用户消息 > cwd basename > short id。用户最开始给出的 `this-week` 日期范围仅作为展示问题示例，本次不按该例子改 period 语义。
+
+## Key Changes
+
+- TUI toolbar 去掉日历 emoji；`today` 只显示本地日期和时区，非 `today` 显示真实 `Window.Start ～ Window.End` 和时区。
+- 扩展 `usage.UsageEvent` 会话元信息：`thread_id`、`thread_name`、`thread_source`、`thread_created_at`、`thread_last_active_at`。
+- Codex/Claude 用 head/tail 少量读取提取 session 元信息；跳过 AGENTS/environment 注入、slash command caveat、subagent/agent 会话。
+- Gemini 增加会话文件扫描能力，优先从 `~/.gemini/tmp/<project>/chats/session-*.json` 与 `.project_root` 读取 `sessionId/startTime/lastUpdated/messages`。
+- `summary --threads` 输出 `threads` 数组，继承 `period/tool/model/provider/cwd/pricing/format`；默认 summary 不带 threads。
+- TUI 新增 Threads BOX：固定表头、当前行高亮、右侧滚动条；不做翻页，不做展开/收起。
+- 支持 `t` 聚焦/退出 threads 窗口，`↑/↓` 或 `j/k` 移动，`home/end` 跳转首尾，`c` 快速复制选中 thread ID。
+
+## Implementation Changes
+
+- 新增或扩展 `internal/query.ThreadResult` 和线程聚合器，字段包含 `id/name/model/provider/tool/usage/requests/events/cost_usd/source/created_at/last_active_at`。
+- `internal/sources` 增加会话元信息提取辅助函数，保持 JSONL 逐行读取；Codex/Claude 不读取全文，只读取 head/tail；Gemini session JSON 可按文件读取，但不上传、不联网。
+- `report.Payload` 新增 `period` 和可选 `threads,omitempty`；table/markdown 在 `--threads` 时追加 Threads 表。
+- `internal/tui` 增加 `focusedPane`、`threadCursor`、`threadOffset`、`copyStatus` 状态，并按 BOX 高度裁剪 threads 行；实现焦点驱动滚动条。
+- 更新 `README.md` / `README.zh-CN.md`，补充 `summary --threads --format json --no-version-check` 和 TUI threads 快捷键。
+
+## Test Plan
+
+- `go test ./internal/sources ./internal/query ./internal/report ./internal/tui ./internal/cli`
+- `make check`
+- `make test`
+- `make build`
+- Source tests：custom title 优先于 AI 总结标题；AI 总结标题优先于首条用户消息；首条用户消息优先于 cwd basename；无可用标题时回退 short id。
+- Query/report tests：同一 thread 多事件聚合 token、requests、events、cost；过滤后 threads 与 summary 窗口一致；未传 `--threads` 时 JSON 不含 `threads`。
+- TUI tests：日期无 emoji；today 不显示范围；非 today 显示真实窗口；threads box 渲染表头、高亮行、滚动条；`j/k/home/end/c` 更新状态正确；无 `pgup/pgdn/enter` 交互。
+
+## Assumptions
+
+- “AI 总结标题”实现为读取日志中的显式标题/总结字段或尾部标题事件，不调用模型生成标题，不联网。
+- `this-week` 不做特殊语义调整；展示始终以实际查询窗口为准。
+- Threads 交互优先在 TUI 交付，CLI 的 `summary --threads` 作为机器可解析入口。
+- “快速复制 ID”默认复制 thread/session ID，不复制 resume 命令；后续可再加 `r` 复制 `codex resume <id>` / `claude --resume <id>`。

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -58,6 +58,7 @@ type flags struct {
 	pricing        string
 	lang           string
 	renderTUI      bool
+	threads        bool
 	dryRun         bool
 	noVersionCheck bool
 	version        bool
@@ -113,6 +114,7 @@ func New(app App) *cobra.Command {
 		},
 	}
 	addQueryFlags(summary, f)
+	summary.Flags().BoolVar(&f.threads, "threads", false, "include matching threads in the output")
 
 	reportCmd := &cobra.Command{
 		Use:   "report",
@@ -179,6 +181,7 @@ func New(app App) *cobra.Command {
 		Use:   "tui",
 		Short: "Open the terminal dashboard",
 		RunE: func(cmd *cobra.Command, args []string) error {
+			f.threads = true
 			payload, err := buildPayload(cmd.Context(), f, app.Now())
 			if err != nil {
 				return err
@@ -302,14 +305,30 @@ func buildPayload(ctx context.Context, f *flags, now time.Time) (report.Payload,
 	}, groupBy, func(event usage.UsageEvent) query.Cost {
 		return query.Cost{USD: catalog.CostFor(event).USD}
 	})
+	filters := query.Filters{
+		Tools:     query.SplitCSV(f.tools),
+		Models:    query.SplitCSV(f.models),
+		Providers: query.SplitCSV(f.providers),
+		CWD:       f.cwd,
+	}
+	threadAcc := query.NewThreadAccumulator(window, filters, func(event usage.UsageEvent) query.Cost {
+		return query.Cost{USD: catalog.CostFor(event).USD}
+	})
 	err = sources.ForEach(ctx, sources.Defaults(opts), func(event usage.UsageEvent) error {
 		acc.Add(event)
+		if f.threads || f.renderTUI {
+			threadAcc.Add(event)
+		}
 		return nil
 	})
 	if err != nil {
 		return report.Payload{}, err
 	}
-	return report.Payload{GeneratedAt: now, Window: window, GroupBy: groupBy, Results: acc.Results()}, nil
+	payload := report.Payload{GeneratedAt: now, Period: period, Window: window, GroupBy: groupBy, Results: acc.Results()}
+	if f.threads || f.renderTUI {
+		payload.Threads = threadAcc.Results()
+	}
+	return payload, nil
 }
 
 func loadPricing(f *flags, home string) (pricing.Catalog, error) {

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -72,6 +72,37 @@ func TestAgentJSONSummaryKeepsStdoutMachineReadableAndStderrEmpty(t *testing.T) 
 	}
 }
 
+func TestSummaryJSONOmitsThreadsByDefaultAndIncludesWithFlag(t *testing.T) {
+	home := t.TempDir()
+	session := filepath.Join(home, ".codex", "sessions", "2026", "05", "08", "rollout-2026-05-08T01-00-00-019e0000-0000-7000-8000-000000000001.jsonl")
+	writeFixture(t, session,
+		`{"type":"session_meta","timestamp":"2026-05-08T01:00:00Z","payload":{"id":"thread-a","model_provider":"openai","cwd":"/repo"}}`+"\n"+
+			`{"type":"response_item","timestamp":"2026-05-08T01:00:01Z","payload":{"type":"message","role":"user","content":"Fix login bug"}}`+"\n"+
+			`{"type":"turn_context","timestamp":"2026-05-08T01:00:02Z","payload":{"id":"turn-a","model":"gpt-5.4","cwd":"/repo"}}`+"\n"+
+			`{"type":"event_msg","timestamp":"2026-05-08T01:00:03Z","payload":{"type":"token_count","info":{"last_token_usage":{"input_tokens":10,"output_tokens":2,"total_tokens":12}}}}`+"\n")
+	now := func() time.Time { return time.Date(2026, 5, 8, 12, 0, 0, 0, time.UTC) }
+
+	var out bytes.Buffer
+	cmd := New(App{Out: &out, Now: now})
+	cmd.SetArgs([]string{"--home", home, "--no-version-check", "summary", "--period", "today", "--format", "json"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(out.String(), `"threads"`) {
+		t.Fatalf("summary JSON should omit threads by default: %s", out.String())
+	}
+
+	out.Reset()
+	cmd = New(App{Out: &out, Now: now})
+	cmd.SetArgs([]string{"--home", home, "--no-version-check", "summary", "--period", "today", "--format", "json", "--threads"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out.String(), `"threads"`) || !strings.Contains(out.String(), `"id": "thread-a"`) || !strings.Contains(out.String(), `"name": "Fix login bug"`) {
+		t.Fatalf("summary --threads should include thread payload: %s", out.String())
+	}
+}
+
 func TestSummaryUsesCustomPricingFile(t *testing.T) {
 	home := t.TempDir()
 	pricingPath := filepath.Join(home, "pricing.json")

--- a/internal/query/query.go
+++ b/internal/query/query.go
@@ -30,12 +30,34 @@ type Result struct {
 	Examples map[string]string `json:"examples,omitempty"`
 }
 
+type ThreadResult struct {
+	ID           string           `json:"id"`
+	Name         string           `json:"name"`
+	Tool         string           `json:"tool"`
+	Model        string           `json:"model"`
+	Provider     string           `json:"provider"`
+	Source       string           `json:"source,omitempty"`
+	CreatedAt    time.Time        `json:"created_at,omitempty"`
+	LastActiveAt time.Time        `json:"last_active_at,omitempty"`
+	Events       int              `json:"events"`
+	Requests     int              `json:"requests"`
+	CostUSD      float64          `json:"cost_usd"`
+	Usage        usage.TokenUsage `json:"usage"`
+}
+
 type Accumulator struct {
 	window  Window
 	filters Filters
 	groupBy GroupBy
 	costFor func(usage.UsageEvent) Cost
 	buckets map[string]*Result
+}
+
+type ThreadAccumulator struct {
+	window  Window
+	filters Filters
+	costFor func(usage.UsageEvent) Cost
+	buckets map[string]*ThreadResult
 }
 
 func DefaultGroupBy() GroupBy {
@@ -75,6 +97,10 @@ func NewAccumulator(window Window, filters Filters, groupBy GroupBy, costFor fun
 	return &Accumulator{window: window, filters: filters, groupBy: groupBy, costFor: costFor, buckets: map[string]*Result{}}
 }
 
+func NewThreadAccumulator(window Window, filters Filters, costFor func(usage.UsageEvent) Cost) *ThreadAccumulator {
+	return &ThreadAccumulator{window: window, filters: filters, costFor: costFor, buckets: map[string]*ThreadResult{}}
+}
+
 func (a *Accumulator) Add(event usage.UsageEvent) {
 	if !a.window.Contains(event.Timestamp) || !matches(event, a.filters) {
 		return
@@ -108,6 +134,73 @@ func (a *Accumulator) Results() []Result {
 		right := results[j].Usage.NormalizedTotal()
 		if left == right {
 			return serializeKey(a.groupBy, results[i].Key) < serializeKey(a.groupBy, results[j].Key)
+		}
+		return left > right
+	})
+	return results
+}
+
+func (a *ThreadAccumulator) Add(event usage.UsageEvent) {
+	if !a.window.Contains(event.Timestamp) || !matches(event, a.filters) {
+		return
+	}
+	id := usage.Unknown(event.ThreadID)
+	if id == "unknown" {
+		id = event.ID
+	}
+	if id == "" {
+		return
+	}
+	bucket := a.buckets[string(event.Tool)+"|"+id]
+	if bucket == nil {
+		bucket = &ThreadResult{
+			ID:           id,
+			Name:         usage.Unknown(event.ThreadName),
+			Tool:         string(event.Tool),
+			Model:        usage.Unknown(event.Model),
+			Provider:     usage.Unknown(event.Provider),
+			Source:       event.ThreadSource,
+			CreatedAt:    event.ThreadCreatedAt,
+			LastActiveAt: event.ThreadLastActiveAt,
+		}
+		a.buckets[string(event.Tool)+"|"+id] = bucket
+	}
+	bucket.Events++
+	bucket.Requests++
+	bucket.Usage = bucket.Usage.Add(event.Usage)
+	if a.costFor != nil {
+		bucket.CostUSD += a.costFor(event).USD
+	}
+	if bucket.Name == "unknown" && event.ThreadName != "" {
+		bucket.Name = event.ThreadName
+	}
+	if bucket.Model == "unknown" && event.Model != "" {
+		bucket.Model = event.Model
+	}
+	if bucket.Provider == "unknown" && event.Provider != "" {
+		bucket.Provider = event.Provider
+	}
+	if bucket.Source == "" {
+		bucket.Source = event.ThreadSource
+	}
+	if bucket.CreatedAt.IsZero() {
+		bucket.CreatedAt = event.ThreadCreatedAt
+	}
+	if bucket.LastActiveAt.IsZero() || event.Timestamp.After(bucket.LastActiveAt) {
+		bucket.LastActiveAt = event.Timestamp
+	}
+}
+
+func (a *ThreadAccumulator) Results() []ThreadResult {
+	results := make([]ThreadResult, 0, len(a.buckets))
+	for _, result := range a.buckets {
+		results = append(results, *result)
+	}
+	sort.Slice(results, func(i, j int) bool {
+		left := results[i].Usage.NormalizedTotal()
+		right := results[j].Usage.NormalizedTotal()
+		if left == right {
+			return results[i].Tool+"|"+results[i].ID < results[j].Tool+"|"+results[j].ID
 		}
 		return left > right
 	})

--- a/internal/query/query_test.go
+++ b/internal/query/query_test.go
@@ -84,3 +84,31 @@ func TestAccumulatorMatchesAggregateWithCosts(t *testing.T) {
 		t.Fatalf("usage = %+v, want %+v", got[0].Usage, wantUsage)
 	}
 }
+
+func TestThreadAccumulatorGroupsUsageAndCostByThread(t *testing.T) {
+	loc := time.UTC
+	window := Window{Start: time.Date(2026, 5, 8, 0, 0, 0, 0, loc), End: time.Date(2026, 5, 9, 0, 0, 0, 0, loc)}
+	events := []usage.UsageEvent{
+		{ID: "a", Timestamp: time.Date(2026, 5, 8, 1, 0, 0, 0, loc), Tool: usage.ToolCodex, Model: "gpt-5.4", Provider: "openai", CWD: "/repo", ThreadID: "thread-a", ThreadName: "Custom title", ThreadSource: "/tmp/a.jsonl", Usage: usage.TokenUsage{Input: 1_000_000}},
+		{ID: "b", Timestamp: time.Date(2026, 5, 8, 2, 0, 0, 0, loc), Tool: usage.ToolCodex, Model: "gpt-5.4", Provider: "openai", CWD: "/repo", ThreadID: "thread-a", ThreadName: "Custom title", ThreadSource: "/tmp/a.jsonl", Usage: usage.TokenUsage{Output: 100_000}},
+		{ID: "c", Timestamp: time.Date(2026, 5, 8, 3, 0, 0, 0, loc), Tool: usage.ToolClaude, Model: "claude", Provider: "unknown", ThreadID: "thread-b", ThreadName: "Other", Usage: usage.TokenUsage{Input: 2}},
+		{ID: "old", Timestamp: time.Date(2026, 5, 7, 1, 0, 0, 0, loc), Tool: usage.ToolCodex, Model: "gpt-5.4", Provider: "openai", ThreadID: "old", Usage: usage.TokenUsage{Input: 9}},
+	}
+	acc := NewThreadAccumulator(window, Filters{Tools: []string{"codex"}}, func(event usage.UsageEvent) Cost {
+		return Cost{USD: float64(event.Usage.Input)/1_000_000 + float64(event.Usage.Output)/100_000}
+	})
+	for _, event := range events {
+		acc.Add(event)
+	}
+	got := acc.Results()
+	if len(got) != 1 {
+		t.Fatalf("len(threads) = %d, want 1", len(got))
+	}
+	thread := got[0]
+	if thread.ID != "thread-a" || thread.Name != "Custom title" || thread.Tool != "codex" || thread.Source != "/tmp/a.jsonl" {
+		t.Fatalf("unexpected thread metadata: %+v", thread)
+	}
+	if thread.Requests != 2 || thread.Events != 2 || thread.Usage.NormalizedTotal() != 1_100_000 || thread.CostUSD != 2 {
+		t.Fatalf("unexpected thread totals: %+v", thread)
+	}
+}

--- a/internal/report/report.go
+++ b/internal/report/report.go
@@ -12,25 +12,64 @@ import (
 )
 
 type Payload struct {
-	GeneratedAt time.Time      `json:"generated_at"`
-	Window      query.Window   `json:"window"`
-	GroupBy     query.GroupBy  `json:"group_by"`
-	Results     []query.Result `json:"results"`
+	GeneratedAt time.Time            `json:"generated_at"`
+	Period      query.Period         `json:"period,omitempty"`
+	Window      query.Window         `json:"window"`
+	GroupBy     query.GroupBy        `json:"group_by"`
+	Results     []query.Result       `json:"results"`
+	Threads     []query.ThreadResult `json:"threads,omitempty"`
 }
 
 func Write(w io.Writer, format string, payload Payload) error {
 	switch format {
 	case "", "table":
-		return WriteTable(w, payload.Results)
+		if err := WriteTable(w, payload.Results); err != nil {
+			return err
+		}
+		if len(payload.Threads) > 0 {
+			if _, err := fmt.Fprintln(w); err != nil {
+				return err
+			}
+			return WriteThreadsTable(w, payload.Threads)
+		}
+		return nil
 	case "json":
 		encoder := json.NewEncoder(w)
 		encoder.SetIndent("", "  ")
 		return encoder.Encode(payload)
 	case "markdown":
-		return WriteMarkdown(w, payload.Results)
+		if err := WriteMarkdown(w, payload.Results); err != nil {
+			return err
+		}
+		if len(payload.Threads) > 0 {
+			if _, err := fmt.Fprintln(w, "\n## Threads"); err != nil {
+				return err
+			}
+			return WriteThreadsMarkdown(w, payload.Threads)
+		}
+		return nil
 	default:
 		return fmt.Errorf("unknown format %q", format)
 	}
+}
+
+func WriteThreadsTable(w io.Writer, threads []query.ThreadResult) error {
+	headers := []string{"ID", "NAME", "TOOL", "MODEL", "PROVIDER", "REQUESTS", "EVENTS", "COST_USD", "TOTAL"}
+	rows := make([][]string, 0, len(threads))
+	for _, thread := range threads {
+		rows = append(rows, []string{
+			thread.ID,
+			thread.Name,
+			thread.Tool,
+			thread.Model,
+			thread.Provider,
+			fmt.Sprint(thread.Requests),
+			fmt.Sprint(thread.Events),
+			FormatUSD(thread.CostUSD),
+			fmt.Sprint(thread.Usage.NormalizedTotal()),
+		})
+	}
+	return writeBorderedTable(w, headers, rows)
 }
 
 func WriteTable(w io.Writer, results []query.Result) error {
@@ -133,6 +172,31 @@ func WriteMarkdown(w io.Writer, results []query.Result) error {
 			result.Usage.Reasoning,
 			result.Usage.Tool,
 			result.Usage.NormalizedTotal(),
+		); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func WriteThreadsMarkdown(w io.Writer, threads []query.ThreadResult) error {
+	if _, err := fmt.Fprintln(w, "| ID | Name | Tool | Model | Provider | Requests | Events | Cost USD | Total |"); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintln(w, "| --- | --- | --- | --- | --- | ---: | ---: | ---: | ---: |"); err != nil {
+		return err
+	}
+	for _, thread := range threads {
+		if _, err := fmt.Fprintf(w, "| %s | %s | %s | %s | %s | %d | %d | %s | %d |\n",
+			escapeMarkdown(thread.ID),
+			escapeMarkdown(thread.Name),
+			escapeMarkdown(thread.Tool),
+			escapeMarkdown(thread.Model),
+			escapeMarkdown(thread.Provider),
+			thread.Requests,
+			thread.Events,
+			FormatUSD(thread.CostUSD),
+			thread.Usage.NormalizedTotal(),
 		); err != nil {
 			return err
 		}

--- a/internal/report/report_test.go
+++ b/internal/report/report_test.go
@@ -58,3 +58,40 @@ func TestWriteTableIncludesRequestsAndCost(t *testing.T) {
 		t.Fatalf("table must render borders and column separators: %s", got)
 	}
 }
+
+func TestWriteThreadsWhenPayloadIncludesThreads(t *testing.T) {
+	payload := Payload{
+		Results: []query.Result{{
+			Key:      map[string]string{"tool": "codex"},
+			Requests: 1,
+			Events:   1,
+			Usage:    usage.TokenUsage{Input: 5},
+		}},
+		Threads: []query.ThreadResult{{
+			ID:       "thread-a",
+			Name:     "Custom title",
+			Tool:     "codex",
+			Model:    "gpt-5.4",
+			Provider: "openai",
+			Requests: 1,
+			Events:   1,
+			Usage:    usage.TokenUsage{Input: 5},
+			CostUSD:  0.0001,
+		}},
+	}
+	var out bytes.Buffer
+	if err := Write(&out, "markdown", payload); err != nil {
+		t.Fatal(err)
+	}
+	got := out.String()
+	if !strings.Contains(got, "## Threads") || !strings.Contains(got, "| thread-a | Custom title | codex | gpt-5.4 | openai |") {
+		t.Fatalf("markdown output missing threads: %s", got)
+	}
+	out.Reset()
+	if err := Write(&out, "json", payload); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out.String(), `"threads"`) || !strings.Contains(out.String(), `"id": "thread-a"`) {
+		t.Fatalf("json output missing threads: %s", out.String())
+	}
+}

--- a/internal/sources/claude.go
+++ b/internal/sources/claude.go
@@ -40,8 +40,12 @@ func (c Claude) Scan(ctx context.Context, handle func(usage.UsageEvent) error) e
 		if err != nil || d == nil || d.IsDir() || filepath.Ext(path) != ".jsonl" {
 			return nil
 		}
+		meta := parseClaudeThreadMeta(path)
+		if meta.Skip {
+			return nil
+		}
 		return readJSONLines(ctx, path, func(obj map[string]any) error {
-			event, ok := c.parseEvent(path, obj)
+			event, ok := c.parseEvent(path, obj, meta)
 			if !ok {
 				return nil
 			}
@@ -55,7 +59,7 @@ func (c Claude) Scan(ctx context.Context, handle func(usage.UsageEvent) error) e
 	return err
 }
 
-func (c Claude) parseEvent(path string, obj map[string]any) (usage.UsageEvent, bool) {
+func (c Claude) parseEvent(path string, obj map[string]any, meta threadMeta) (usage.UsageEvent, bool) {
 	if stringValue(obj["type"]) != "assistant" {
 		return usage.UsageEvent{}, false
 	}
@@ -86,14 +90,19 @@ func (c Claude) parseEvent(path string, obj map[string]any) (usage.UsageEvent, b
 		id = claudeHash(ts, model, tokens)
 	}
 	return usage.UsageEvent{
-		ID:        id,
-		Timestamp: ts,
-		Tool:      usage.ToolClaude,
-		Model:     model,
-		Provider:  "unknown",
-		CWD:       stringValue(obj["cwd"]),
-		Source:    path,
-		Usage:     tokens,
+		ID:                 id,
+		Timestamp:          ts,
+		Tool:               usage.ToolClaude,
+		Model:              model,
+		Provider:           "unknown",
+		CWD:                stringValue(obj["cwd"]),
+		Source:             path,
+		ThreadID:           meta.ID,
+		ThreadName:         meta.Name,
+		ThreadSource:       meta.Source,
+		ThreadCreatedAt:    meta.CreatedAt,
+		ThreadLastActiveAt: meta.LastActiveAt,
+		Usage:              tokens,
 	}, true
 }
 

--- a/internal/sources/codex.go
+++ b/internal/sources/codex.go
@@ -35,12 +35,20 @@ func (c Codex) Read(ctx context.Context) ([]usage.UsageEvent, error) {
 
 func (c Codex) Scan(ctx context.Context, handle func(usage.UsageEvent) error) error {
 	root := filepath.Join(c.Home, ".codex", "sessions")
+	index := readCodexSessionIndex(filepath.Join(c.Home, ".codex", "session_index.jsonl"))
 	seen := map[string]struct{}{}
 	return filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
 		if err != nil || d == nil || d.IsDir() || filepath.Ext(path) != ".jsonl" {
 			return nil
 		}
-		state := codexState{provider: "unknown", model: "unknown"}
+		meta := parseCodexThreadMeta(path)
+		if meta.Skip {
+			return nil
+		}
+		if title := index[meta.ID]; title != "" {
+			meta.Name = chooseThreadTitle(title, meta.Name)
+		}
+		state := codexState{provider: "unknown", model: "unknown", thread: meta}
 		return readJSONLines(ctx, path, func(obj map[string]any) error {
 			state.update(obj)
 			event, ok := c.parseEvent(path, obj, state)
@@ -61,6 +69,7 @@ type codexState struct {
 	model    string
 	cwd      string
 	turnID   string
+	thread   threadMeta
 }
 
 func (s *codexState) update(obj map[string]any) {
@@ -117,14 +126,19 @@ func (c Codex) parseEvent(path string, obj map[string]any, state codexState) (us
 	}
 	id := codexHash(ts, tokens, codexUsageFingerprint(rawTotalUsage))
 	return usage.UsageEvent{
-		ID:        state.turnID + ":" + id,
-		Timestamp: ts,
-		Tool:      usage.ToolCodex,
-		Model:     usage.Unknown(state.model),
-		Provider:  usage.Unknown(state.provider),
-		CWD:       state.cwd,
-		Source:    path,
-		Usage:     tokens,
+		ID:                 state.turnID + ":" + id,
+		Timestamp:          ts,
+		Tool:               usage.ToolCodex,
+		Model:              usage.Unknown(state.model),
+		Provider:           usage.Unknown(state.provider),
+		CWD:                state.cwd,
+		Source:             path,
+		ThreadID:           state.thread.ID,
+		ThreadName:         state.thread.Name,
+		ThreadSource:       state.thread.Source,
+		ThreadCreatedAt:    state.thread.CreatedAt,
+		ThreadLastActiveAt: state.thread.LastActiveAt,
+		Usage:              tokens,
 	}, true
 }
 

--- a/internal/sources/gemini.go
+++ b/internal/sources/gemini.go
@@ -37,8 +37,18 @@ func (g Gemini) Scan(ctx context.Context, handle func(usage.UsageEvent) error) e
 	if outfile == "" {
 		return nil
 	}
+	threads := g.sessionMetaByID()
 	err := readJSONLines(ctx, outfile, func(obj map[string]any) error {
 		if event, ok := g.parseEvent(outfile, obj); ok {
+			if meta, found := threads[event.ThreadID]; found {
+				event.ThreadName = meta.Name
+				event.ThreadSource = meta.Source
+				event.ThreadCreatedAt = meta.CreatedAt
+				event.ThreadLastActiveAt = meta.LastActiveAt
+				if event.CWD == "" {
+					event.CWD = meta.CWD
+				}
+			}
 			return handle(event)
 		}
 		return nil
@@ -98,14 +108,91 @@ func (g Gemini) parseEvent(path string, obj map[string]any) (usage.UsageEvent, b
 		id = path + "|" + ts.Format(time.RFC3339Nano) + "|" + model
 	}
 	return usage.UsageEvent{
-		ID:        id,
-		Timestamp: ts,
-		Tool:      usage.ToolGemini,
-		Model:     usage.Unknown(model),
-		Provider:  usage.Unknown(provider),
-		Source:    path,
-		Usage:     tokens,
+		ID:           id,
+		Timestamp:    ts,
+		Tool:         usage.ToolGemini,
+		Model:        usage.Unknown(model),
+		Provider:     usage.Unknown(provider),
+		Source:       path,
+		ThreadID:     id,
+		ThreadName:   usage.Unknown(id),
+		ThreadSource: path,
+		Usage:        tokens,
 	}, true
+}
+
+func (g Gemini) sessionMetaByID() map[string]threadMeta {
+	out := map[string]threadMeta{}
+	tmpDir := filepath.Join(g.Home, ".gemini", "tmp")
+	entries, err := os.ReadDir(tmpDir)
+	if err != nil {
+		return out
+	}
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		projectRoot := strings.TrimSpace(readString(filepath.Join(tmpDir, entry.Name(), ".project_root")))
+		chatsDir := filepath.Join(tmpDir, entry.Name(), "chats")
+		files, err := os.ReadDir(chatsDir)
+		if err != nil {
+			continue
+		}
+		for _, file := range files {
+			if file.IsDir() || filepath.Ext(file.Name()) != ".json" {
+				continue
+			}
+			path := filepath.Join(chatsDir, file.Name())
+			if meta, ok := parseGeminiSessionMeta(path, projectRoot); ok {
+				out[meta.ID] = meta
+			}
+		}
+	}
+	return out
+}
+
+func parseGeminiSessionMeta(path, cwd string) (threadMeta, bool) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return threadMeta{}, false
+	}
+	var obj map[string]any
+	if err := json.Unmarshal(data, &obj); err != nil {
+		return threadMeta{}, false
+	}
+	id := stringValue(obj["sessionId"])
+	if id == "" {
+		return threadMeta{}, false
+	}
+	meta := threadMeta{
+		ID:           id,
+		CWD:          cwd,
+		Source:       path,
+		CreatedAt:    parseTimestamp(stringValue(obj["startTime"])),
+		LastActiveAt: parseTimestamp(stringValue(obj["lastUpdated"])),
+	}
+	if messages, ok := obj["messages"].([]any); ok {
+		for _, msg := range messages {
+			m := objectValue(msg)
+			if m == nil || stringValue(m["type"]) != "user" {
+				continue
+			}
+			if text := extractText(m["content"]); strings.TrimSpace(text) != "" {
+				meta.Name = truncateTitle(text)
+				break
+			}
+		}
+	}
+	meta.Name = chooseThreadTitle(meta.Name, pathBase(cwd), shortID(id))
+	return meta, true
+}
+
+func readString(path string) string {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return ""
+	}
+	return string(data)
 }
 
 func isGeminiUsage(flat map[string]any) bool {

--- a/internal/sources/session_meta.go
+++ b/internal/sources/session_meta.go
@@ -1,0 +1,345 @@
+package sources
+
+import (
+	"bufio"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"time"
+)
+
+const titleMaxChars = 160
+
+var codexUUIDRE = regexp.MustCompile(`[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}`)
+
+type threadMeta struct {
+	ID           string
+	Name         string
+	Source       string
+	CWD          string
+	CreatedAt    time.Time
+	LastActiveAt time.Time
+	Skip         bool
+}
+
+func readHeadTailJSON(path string, headCount, tailCount int) ([]map[string]any, []map[string]any) {
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, nil
+	}
+	defer file.Close()
+	scanner := bufio.NewScanner(file)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	var head []map[string]any
+	var tail []map[string]any
+	for scanner.Scan() {
+		var obj map[string]any
+		if err := json.Unmarshal([]byte(scanner.Text()), &obj); err != nil {
+			continue
+		}
+		if len(head) < headCount {
+			head = append(head, obj)
+		}
+		tail = append(tail, obj)
+		if len(tail) > tailCount {
+			tail = tail[1:]
+		}
+	}
+	return head, tail
+}
+
+func readCodexSessionIndex(path string) map[string]string {
+	file, err := os.Open(path)
+	if err != nil {
+		return nil
+	}
+	defer file.Close()
+	titles := map[string]string{}
+	scanner := bufio.NewScanner(file)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	for scanner.Scan() {
+		var obj map[string]any
+		if err := json.Unmarshal([]byte(scanner.Text()), &obj); err != nil {
+			continue
+		}
+		id := stringValue(obj["id"])
+		title := firstNonEmptyString(obj, "thread_name", "threadName", "title", "name")
+		if id != "" && title != "" {
+			titles[id] = title
+		}
+	}
+	return titles
+}
+
+func parseCodexThreadMeta(path string) threadMeta {
+	head, tail := readHeadTailJSON(path, 40, 80)
+	meta := threadMeta{Source: path}
+	var customTitle, summaryTitle, firstUser string
+	for _, obj := range head {
+		ts := parseTimestamp(stringValue(obj["timestamp"]))
+		if meta.CreatedAt.IsZero() && !ts.IsZero() {
+			meta.CreatedAt = ts
+		}
+		switch stringValue(obj["type"]) {
+		case "session_meta":
+			payload := objectValue(obj["payload"])
+			if hasSubagentSource(payload) {
+				meta.Skip = true
+				return meta
+			}
+			if meta.ID == "" {
+				meta.ID = stringValue(payload["id"])
+			}
+			if meta.CWD == "" {
+				meta.CWD = stringValue(payload["cwd"])
+			}
+		case "response_item":
+			if firstUser == "" {
+				if text, ok := codexMessageText(obj, "user"); ok && isRealUserTitle(text) {
+					firstUser = text
+				}
+			}
+		}
+	}
+	for i := len(tail) - 1; i >= 0; i-- {
+		obj := tail[i]
+		if meta.LastActiveAt.IsZero() {
+			meta.LastActiveAt = parseTimestamp(stringValue(obj["timestamp"]))
+		}
+		if customTitle == "" {
+			customTitle = firstNonEmptyString(obj, "customTitle", "title")
+			if customTitle == "" && stringValue(obj["type"]) == "custom-title" {
+				customTitle = firstNonEmptyString(obj, "custom_title", "name")
+			}
+		}
+		if summaryTitle == "" {
+			summaryTitle = codexExplicitTitle(obj)
+		}
+	}
+	if meta.ID == "" {
+		meta.ID = inferCodexID(path)
+	}
+	meta.Name = chooseThreadTitle(customTitle, summaryTitle, firstUser, pathBase(meta.CWD), shortID(meta.ID))
+	return meta
+}
+
+func codexExplicitTitle(obj map[string]any) string {
+	title := firstNonEmptyString(obj, "summary", "summary_title", "summaryTitle", "thread_title", "threadTitle")
+	if title != "" {
+		return title
+	}
+	switch stringValue(obj["type"]) {
+	case "thread-title", "thread_title", "conversation-title", "conversation_title", "title":
+		if title := firstNonEmptyString(obj, "title", "name", "thread_name", "threadName", "summary", "text"); title != "" {
+			return title
+		}
+	}
+	payload := objectValue(obj["payload"])
+	if payload == nil {
+		return ""
+	}
+	title = firstNonEmptyString(payload, "summary", "summary_title", "summaryTitle", "thread_title", "threadTitle")
+	if title != "" {
+		return title
+	}
+	switch stringValue(payload["type"]) {
+	case "thread-title", "thread_title", "conversation-title", "conversation_title", "title":
+		return firstNonEmptyString(payload, "title", "name", "thread_name", "threadName", "summary", "text")
+	default:
+		return ""
+	}
+}
+
+func parseClaudeThreadMeta(path string) threadMeta {
+	if strings.HasPrefix(filepath.Base(path), "agent-") {
+		return threadMeta{Source: path, Skip: true}
+	}
+	head, tail := readHeadTailJSON(path, 40, 80)
+	meta := threadMeta{Source: path}
+	var customTitle, summaryTitle, firstUser string
+	for _, obj := range head {
+		if meta.ID == "" {
+			meta.ID = stringValue(obj["sessionId"])
+		}
+		if meta.CWD == "" {
+			meta.CWD = stringValue(obj["cwd"])
+		}
+		ts := parseTimestamp(stringValue(obj["timestamp"]))
+		if meta.CreatedAt.IsZero() && !ts.IsZero() {
+			meta.CreatedAt = ts
+		}
+		if firstUser == "" && isClaudeUserMessage(obj) {
+			if msg := objectValue(obj["message"]); msg != nil {
+				text := extractText(msg["content"])
+				if isRealClaudeTitle(text) {
+					firstUser = text
+				}
+			}
+		}
+	}
+	for i := len(tail) - 1; i >= 0; i-- {
+		obj := tail[i]
+		if meta.LastActiveAt.IsZero() {
+			meta.LastActiveAt = parseTimestamp(stringValue(obj["timestamp"]))
+		}
+		if customTitle == "" && stringValue(obj["type"]) == "custom-title" {
+			customTitle = firstNonEmptyString(obj, "customTitle", "custom_title", "title")
+		}
+		if summaryTitle == "" && objectValue(obj["message"]) != nil {
+			text := extractText(objectValue(obj["message"])["content"])
+			if strings.TrimSpace(text) != "" {
+				summaryTitle = text
+			}
+		}
+	}
+	if meta.ID == "" {
+		meta.ID = strings.TrimSuffix(filepath.Base(path), filepath.Ext(path))
+	}
+	meta.Name = chooseThreadTitle(customTitle, summaryTitle, firstUser, pathBase(meta.CWD), shortID(meta.ID))
+	return meta
+}
+
+func parseTimestamp(raw string) time.Time {
+	if raw == "" {
+		return time.Time{}
+	}
+	for _, layout := range []string{time.RFC3339Nano, time.RFC3339, "2006-01-02T15:04:05.000Z"} {
+		if ts, err := time.Parse(layout, raw); err == nil {
+			return ts
+		}
+	}
+	return time.Time{}
+}
+
+func firstNonEmptyString(obj map[string]any, keys ...string) string {
+	for _, key := range keys {
+		if value := cleanTitleCandidate(stringValue(obj[key])); value != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func cleanTitleCandidate(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return ""
+	}
+	switch strings.ToLower(value) {
+	case "none", "null", "nil", "unknown":
+		return ""
+	default:
+		return value
+	}
+}
+
+func chooseThreadTitle(values ...string) string {
+	for _, value := range values {
+		if text := truncateTitle(strings.TrimSpace(value)); text != "" {
+			return text
+		}
+	}
+	return "unknown"
+}
+
+func truncateTitle(value string) string {
+	value = strings.Join(strings.Fields(value), " ")
+	if len(value) <= titleMaxChars {
+		return value
+	}
+	if titleMaxChars <= 3 {
+		return value[:titleMaxChars]
+	}
+	return value[:titleMaxChars-3] + "..."
+}
+
+func shortID(id string) string {
+	if len(id) <= 12 {
+		return id
+	}
+	return id[:12]
+}
+
+func pathBase(path string) string {
+	if path == "" {
+		return ""
+	}
+	return filepath.Base(path)
+}
+
+func inferCodexID(path string) string {
+	name := filepath.Base(path)
+	if match := codexUUIDRE.FindString(name); match != "" {
+		return match
+	}
+	return strings.TrimSuffix(name, filepath.Ext(name))
+}
+
+func hasSubagentSource(payload map[string]any) bool {
+	if payload == nil {
+		return false
+	}
+	source := objectValue(payload["source"])
+	if source == nil {
+		return false
+	}
+	_, ok := source["subagent"]
+	return ok
+}
+
+func codexMessageText(obj map[string]any, role string) (string, bool) {
+	if stringValue(obj["type"]) != "response_item" {
+		return "", false
+	}
+	payload := objectValue(obj["payload"])
+	if payload == nil || stringValue(payload["type"]) != "message" || stringValue(payload["role"]) != role {
+		return "", false
+	}
+	text := extractText(payload["content"])
+	return strings.TrimSpace(text), text != ""
+}
+
+func isRealUserTitle(text string) bool {
+	text = strings.TrimSpace(text)
+	return text != "" &&
+		!strings.HasPrefix(text, "# AGENTS.md") &&
+		!strings.HasPrefix(text, "<environment_context>") &&
+		!strings.HasPrefix(text, "<turn_aborted>") &&
+		!strings.HasPrefix(text, "# Context from my IDE setup:")
+}
+
+func isClaudeUserMessage(obj map[string]any) bool {
+	if stringValue(obj["type"]) == "user" {
+		return true
+	}
+	msg := objectValue(obj["message"])
+	return msg != nil && stringValue(msg["role"]) == "user"
+}
+
+func isRealClaudeTitle(text string) bool {
+	text = strings.TrimSpace(text)
+	return text != "" && !strings.Contains(text, "<local-command-caveat>") && !strings.HasPrefix(text, "<command-name>")
+}
+
+func extractText(value any) string {
+	switch v := value.(type) {
+	case string:
+		return v
+	case []any:
+		var parts []string
+		for _, item := range v {
+			if m := objectValue(item); m != nil {
+				if text := stringValue(m["text"]); text != "" {
+					parts = append(parts, text)
+				} else if text := stringValue(m["content"]); text != "" {
+					parts = append(parts, text)
+				}
+			}
+		}
+		return strings.Join(parts, "\n")
+	default:
+		return ""
+	}
+}

--- a/internal/sources/sources_test.go
+++ b/internal/sources/sources_test.go
@@ -123,6 +123,87 @@ func TestCodexKeepsMatchingTokenCountsAcrossTurns(t *testing.T) {
 	}
 }
 
+func TestCodexThreadTitlePriorityAndMetadata(t *testing.T) {
+	home := t.TempDir()
+	dir := filepath.Join(home, ".codex", "sessions", "2026", "05", "08")
+	path := filepath.Join(dir, "rollout-2026-05-08T01-00-00-019e0000-0000-7000-8000-000000000001.jsonl")
+	body := `{"type":"session_meta","timestamp":"2026-05-08T01:00:00Z","payload":{"id":"thread-a","model_provider":"openai","cwd":"/repo"}}` + "\n" +
+		`{"type":"response_item","timestamp":"2026-05-08T01:00:01Z","payload":{"type":"message","role":"user","content":"First real user message"}}` + "\n" +
+		`{"type":"response_item","timestamp":"2026-05-08T01:00:02Z","payload":{"type":"message","role":"assistant","content":"AI summary title"}}` + "\n" +
+		`{"type":"custom-title","timestamp":"2026-05-08T01:00:03Z","customTitle":"Custom title"}` + "\n" +
+		`{"type":"turn_context","timestamp":"2026-05-08T01:00:04Z","payload":{"id":"turn-a","model":"gpt-5.4","cwd":"/repo"}}` + "\n" +
+		`{"type":"event_msg","timestamp":"2026-05-08T01:00:05Z","payload":{"type":"token_count","info":{"last_token_usage":{"input_tokens":10,"output_tokens":2}}}}` + "\n"
+	mustWrite(t, path, body)
+	events, err := NewCodex(Options{Home: home}).Read(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("len(events) = %d, want 1", len(events))
+	}
+	event := events[0]
+	if event.ThreadID != "thread-a" || event.ThreadName != "Custom title" || event.ThreadSource != path || event.ThreadCreatedAt.IsZero() || event.ThreadLastActiveAt.IsZero() {
+		t.Fatalf("unexpected thread metadata: %+v", event)
+	}
+}
+
+func TestCodexThreadTitleFallsBackToAISummaryThenUserThenCWD(t *testing.T) {
+	home := t.TempDir()
+	base := filepath.Join(home, ".codex", "sessions", "2026", "05", "08")
+	mustWrite(t, filepath.Join(home, ".codex", "session_index.jsonl"),
+		`{"id":"ai-thread","thread_name":"Codex UI title"}`+"\n")
+	mustWrite(t, filepath.Join(base, "ai.jsonl"),
+		`{"type":"session_meta","timestamp":"2026-05-08T01:00:00Z","payload":{"id":"ai-thread","cwd":"/repo-a"}}`+"\n"+
+			`{"type":"response_item","timestamp":"2026-05-08T01:00:01Z","payload":{"type":"message","role":"user","content":"First user"}}`+"\n"+
+			`{"type":"response_item","timestamp":"2026-05-08T01:00:02Z","payload":{"type":"message","role":"assistant","content":"AI summary"}}`+"\n"+
+			`{"type":"turn_context","timestamp":"2026-05-08T01:00:03Z","payload":{"model":"gpt-5.4"}}`+"\n"+
+			`{"type":"event_msg","timestamp":"2026-05-08T01:00:04Z","payload":{"type":"token_count","info":{"last_token_usage":{"input_tokens":1}}}}`+"\n")
+	mustWrite(t, filepath.Join(base, "user.jsonl"),
+		`{"type":"session_meta","timestamp":"2026-05-08T02:00:00Z","payload":{"id":"user-thread","cwd":"/repo-b"}}`+"\n"+
+			`{"type":"response_item","timestamp":"2026-05-08T02:00:01Z","payload":{"type":"message","role":"user","content":"User title"}}`+"\n"+
+			`{"type":"turn_context","timestamp":"2026-05-08T02:00:03Z","payload":{"model":"gpt-5.4"}}`+"\n"+
+			`{"type":"event_msg","timestamp":"2026-05-08T02:00:04Z","payload":{"type":"token_count","info":{"last_token_usage":{"input_tokens":1}}}}`+"\n")
+	mustWrite(t, filepath.Join(base, "summary.jsonl"),
+		`{"type":"session_meta","timestamp":"2026-05-08T02:30:00Z","payload":{"id":"summary-thread","cwd":"/repo-summary"}}`+"\n"+
+			`{"type":"response_item","timestamp":"2026-05-08T02:30:01Z","payload":{"type":"message","role":"user","content":"First user summary fallback"}}`+"\n"+
+			`{"type":"response_item","timestamp":"2026-05-08T02:30:02Z","payload":{"type":"thread-title","title":"Explicit AI title"}}`+"\n"+
+			`{"type":"turn_context","timestamp":"2026-05-08T02:30:03Z","payload":{"model":"gpt-5.4"}}`+"\n"+
+			`{"type":"event_msg","timestamp":"2026-05-08T02:30:04Z","payload":{"type":"token_count","info":{"last_token_usage":{"input_tokens":1}}}}`+"\n")
+	mustWrite(t, filepath.Join(base, "assistant.jsonl"),
+		`{"type":"session_meta","timestamp":"2026-05-08T02:40:00Z","payload":{"id":"assistant-thread","cwd":"/repo-assistant"}}`+"\n"+
+			`{"type":"response_item","timestamp":"2026-05-08T02:40:01Z","payload":{"type":"message","role":"user","content":"First user wins"}}`+"\n"+
+			`{"type":"response_item","timestamp":"2026-05-08T02:40:02Z","payload":{"type":"message","role":"assistant","content":"Regular assistant response, not a title"}}`+"\n"+
+			`{"type":"turn_context","timestamp":"2026-05-08T02:40:03Z","payload":{"model":"gpt-5.4"}}`+"\n"+
+			`{"type":"event_msg","timestamp":"2026-05-08T02:40:04Z","payload":{"type":"token_count","info":{"last_token_usage":{"input_tokens":1}}}}`+"\n")
+	mustWrite(t, filepath.Join(base, "ide.jsonl"),
+		`{"type":"session_meta","timestamp":"2026-05-08T02:50:00Z","payload":{"id":"ide-thread","cwd":"/repo-ide"}}`+"\n"+
+			`{"type":"response_item","timestamp":"2026-05-08T02:50:01Z","payload":{"type":"message","role":"user","content":"# Context from my IDE setup:\n\n## Active file: src/main.go"}}`+"\n"+
+			`{"type":"response_item","timestamp":"2026-05-08T02:50:02Z","payload":{"type":"message","role":"user","content":"Real user title"}}`+"\n"+
+			`{"type":"turn_context","timestamp":"2026-05-08T02:50:03Z","payload":{"model":"gpt-5.4","summary":"none"}}`+"\n"+
+			`{"type":"event_msg","timestamp":"2026-05-08T02:50:04Z","payload":{"type":"token_count","info":{"last_token_usage":{"input_tokens":1}}}}`+"\n")
+	mustWrite(t, filepath.Join(base, "aborted.jsonl"),
+		`{"type":"session_meta","timestamp":"2026-05-08T02:55:00Z","payload":{"id":"aborted-thread","cwd":"/repo-aborted"}}`+"\n"+
+			`{"type":"response_item","timestamp":"2026-05-08T02:55:01Z","payload":{"type":"message","role":"user","content":"<turn_aborted> The user interrupted the previous turn on purpose."}}`+"\n"+
+			`{"type":"response_item","timestamp":"2026-05-08T02:55:02Z","payload":{"type":"message","role":"user","content":"Actual request title"}}`+"\n"+
+			`{"type":"turn_context","timestamp":"2026-05-08T02:55:03Z","payload":{"model":"gpt-5.4"}}`+"\n"+
+			`{"type":"event_msg","timestamp":"2026-05-08T02:55:04Z","payload":{"type":"token_count","info":{"last_token_usage":{"input_tokens":1}}}}`+"\n")
+	mustWrite(t, filepath.Join(base, "cwd.jsonl"),
+		`{"type":"session_meta","timestamp":"2026-05-08T03:00:00Z","payload":{"id":"cwd-thread","cwd":"/tmp/my-project"}}`+"\n"+
+			`{"type":"turn_context","timestamp":"2026-05-08T03:00:03Z","payload":{"model":"gpt-5.4"}}`+"\n"+
+			`{"type":"event_msg","timestamp":"2026-05-08T03:00:04Z","payload":{"type":"token_count","info":{"last_token_usage":{"input_tokens":1}}}}`+"\n")
+	events, err := NewCodex(Options{Home: home}).Read(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	names := map[string]string{}
+	for _, event := range events {
+		names[event.ThreadID] = event.ThreadName
+	}
+	if names["ai-thread"] != "Codex UI title" || names["summary-thread"] != "Explicit AI title" || names["assistant-thread"] != "First user wins" || names["ide-thread"] != "Real user title" || names["aborted-thread"] != "Actual request title" || names["user-thread"] != "User title" || names["cwd-thread"] != "my-project" {
+		t.Fatalf("unexpected thread names: %+v", names)
+	}
+}
+
 type streamingSource struct {
 	scanStarted   bool
 	afterCallback bool
@@ -191,6 +272,9 @@ func mustMkdir(t *testing.T, path string) {
 
 func mustWrite(t *testing.T, path, content string) {
 	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
 	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -1,6 +1,7 @@
 package tui
 
 import (
+	"encoding/base64"
 	"fmt"
 	"io"
 	"sort"
@@ -26,13 +27,17 @@ const (
 )
 
 type model struct {
-	payload    report.Payload
-	activeTool string
-	search     string
-	searching  bool
-	width      int
-	language   Language
-	refresh    func() (report.Payload, error)
+	payload      report.Payload
+	activeTool   string
+	search       string
+	searching    bool
+	width        int
+	language     Language
+	refresh      func() (report.Payload, error)
+	focusedPane  string
+	threadCursor int
+	threadOffset int
+	copyStatus   string
 }
 
 type refreshResultMsg struct {
@@ -136,6 +141,36 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.activeTool = string(usage.ToolCodex)
 		case "4":
 			m.activeTool = string(usage.ToolGemini)
+		case "t":
+			if m.focusedPane == "threads" {
+				m.focusedPane = ""
+			} else {
+				m.focusedPane = "threads"
+			}
+		case "up", "k":
+			if m.focusedPane == "threads" {
+				m.moveThreadCursor(-1)
+			}
+		case "down", "j":
+			if m.focusedPane == "threads" {
+				m.moveThreadCursor(1)
+			}
+		case "home":
+			if m.focusedPane == "threads" {
+				m.threadCursor = 0
+				m.ensureThreadVisible()
+			}
+		case "end":
+			if m.focusedPane == "threads" && len(m.payload.Threads) > 0 {
+				m.threadCursor = len(m.payload.Threads) - 1
+				m.ensureThreadVisible()
+			}
+		case "c":
+			if m.focusedPane == "threads" && len(m.payload.Threads) > 0 {
+				id := m.payload.Threads[m.threadCursor].ID
+				m.copyStatus = "copied " + id
+				return m, copyOSC52(id)
+			}
 		}
 	}
 	return m, nil
@@ -177,8 +212,16 @@ func (m model) View() string {
 		b.WriteString("\n\n")
 		b.WriteString(m.table(results))
 	}
+	if len(m.payload.Threads) > 0 {
+		b.WriteString("\n\n")
+		b.WriteString(m.threadsBox(copy))
+	}
 	b.WriteString("\n")
-	b.WriteString(helpStyle.Render(copy.help))
+	help := copy.help
+	if m.copyStatus != "" {
+		help += "  " + m.copyStatus
+	}
+	b.WriteString(helpStyle.Render(help))
 	b.WriteString("\n")
 	return b.String()
 }
@@ -194,11 +237,7 @@ func (m model) toolbar(copy localizedCopy) string {
 	if m.searching {
 		search += "▌"
 	}
-	date := m.payload.Window.Start.Format("2006-01-02")
-	if m.payload.Window.Start.IsZero() {
-		date = copy.today
-	}
-	right := mutedStyle.Render("📅 " + date)
+	right := mutedStyle.Render(m.windowLabel(copy))
 	content := lipgloss.JoinHorizontal(lipgloss.Center, strings.Join(tabs, "  "), "     ", search, "     ", right)
 	return lipgloss.NewStyle().
 		Border(lipgloss.RoundedBorder()).
@@ -206,6 +245,21 @@ func (m model) toolbar(copy localizedCopy) string {
 		Padding(1, 2).
 		Width(clamp(m.width-4, 72, 180)).
 		Render(content)
+}
+
+func (m model) windowLabel(copy localizedCopy) string {
+	start := m.payload.Window.Start
+	if start.IsZero() {
+		return copy.today
+	}
+	zone := start.Location().String()
+	if zone == "Local" {
+		zone, _ = start.Zone()
+	}
+	if m.payload.Period == query.PeriodToday {
+		return start.Format("2006-01-02") + " " + zone
+	}
+	return start.Format("2006-01-02 15:04") + " ～ " + m.payload.Window.End.In(start.Location()).Format("2006-01-02 15:04") + " " + zone
 }
 
 func (m model) cards(summary totals, copy localizedCopy) string {
@@ -280,6 +334,105 @@ func (m model) table(results []query.Result) string {
 	return b.String()
 }
 
+func (m *model) moveThreadCursor(delta int) {
+	if len(m.payload.Threads) == 0 {
+		m.threadCursor = 0
+		m.threadOffset = 0
+		return
+	}
+	m.threadCursor += delta
+	if m.threadCursor < 0 {
+		m.threadCursor = 0
+	}
+	if m.threadCursor >= len(m.payload.Threads) {
+		m.threadCursor = len(m.payload.Threads) - 1
+	}
+	m.ensureThreadVisible()
+}
+
+func (m *model) ensureThreadVisible() {
+	height := m.threadViewportHeight()
+	if m.threadCursor < m.threadOffset {
+		m.threadOffset = m.threadCursor
+	}
+	if m.threadCursor >= m.threadOffset+height {
+		m.threadOffset = m.threadCursor - height + 1
+	}
+	if m.threadOffset < 0 {
+		m.threadOffset = 0
+	}
+}
+
+func (m model) threadViewportHeight() int {
+	if m.width < 100 {
+		return 6
+	}
+	return 10
+}
+
+func (m model) threadsBox(copy localizedCopy) string {
+	threads := m.payload.Threads
+	height := m.threadViewportHeight()
+	if m.threadCursor >= len(threads) {
+		m.threadCursor = len(threads) - 1
+	}
+	if m.threadCursor < 0 {
+		m.threadCursor = 0
+	}
+	if m.threadOffset > len(threads)-1 {
+		m.threadOffset = len(threads) - 1
+	}
+	if m.threadOffset < 0 {
+		m.threadOffset = 0
+	}
+	end := m.threadOffset + height
+	if end > len(threads) {
+		end = len(threads)
+	}
+	header := mutedStyle.Render(fmt.Sprintf("%-12s %-28s %-8s %-18s %-10s %6s %6s %9s %9s %s", "ID", "Name", "Tool", "Model", "Provider", "Req", "Events", "Cost", "Tokens", "│"))
+	var lines []string
+	lines = append(lines, sectionStyle.Render(copy.threads))
+	lines = append(lines, header)
+	for i := m.threadOffset; i < end; i++ {
+		thread := threads[i]
+		scroll := m.scrollBar(i, len(threads), height)
+		line := fmt.Sprintf("%-12s %-28s %-8s %-18s %-10s %6d %6d %9s %9s %s",
+			truncate(thread.ID, 12),
+			truncate(thread.Name, 28),
+			thread.Tool,
+			truncate(thread.Model, 18),
+			truncate(thread.Provider, 10),
+			thread.Requests,
+			thread.Events,
+			report.FormatUSD(thread.CostUSD),
+			compact(thread.Usage.NormalizedTotal()),
+			scroll,
+		)
+		if i == m.threadCursor {
+			line = selectedRowStyle.Render(line)
+		}
+		lines = append(lines, line)
+	}
+	return lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(lipgloss.Color("240")).
+		Padding(1, 2).
+		Width(clamp(m.width-4, 72, 180)).
+		Render(strings.Join(lines, "\n"))
+}
+
+func (m model) scrollBar(index, total, height int) string {
+	if total <= height {
+		return "│"
+	}
+	visibleIndex := index - m.threadOffset
+	thumb := int(float64(m.threadCursor) / float64(total-1) * float64(height-1))
+	if visibleIndex == thumb {
+		return "█"
+	}
+	return "│"
+}
+
 func (m model) filteredResults() []query.Result {
 	var out []query.Result
 	needle := strings.ToLower(strings.TrimSpace(m.search))
@@ -351,6 +504,7 @@ type localizedCopy struct {
 	totalTokens  string
 	cachedTokens string
 	modelUsage   string
+	threads      string
 	empty        string
 	help         string
 }
@@ -368,8 +522,9 @@ func copyFor(language Language) localizedCopy {
 			totalTokens:  "总 Token 数",
 			cachedTokens: "缓存 Token",
 			modelUsage:   "模型用量",
+			threads:      "会话",
 			empty:        "当前查询没有找到用量事件。",
-			help:         "1 全部  2 Claude Code  3 Codex  4 Gemini  / 搜索  esc 清空  l 语言  q 退出",
+			help:         "1 全部  2 Claude Code  3 Codex  4 Gemini  t 会话  j/k 移动  c 复制ID  / 搜索  esc 清空  l 语言  q 退出",
 		}
 	}
 	return localizedCopy{
@@ -383,8 +538,17 @@ func copyFor(language Language) localizedCopy {
 		totalTokens:  "Total Tokens",
 		cachedTokens: "Cached Tokens",
 		modelUsage:   "Model Usage",
+		threads:      "Threads",
 		empty:        "No usage events found for this query.",
-		help:         "1 All  2 Claude Code  3 Codex  4 Gemini  / search  esc clear  l language  q quit",
+		help:         "1 All  2 Claude Code  3 Codex  4 Gemini  t threads  j/k move  c copy ID  / search  esc clear  l language  q quit",
+	}
+}
+
+func copyOSC52(value string) tea.Cmd {
+	return func() tea.Msg {
+		encoded := base64.StdEncoding.EncodeToString([]byte(value))
+		fmt.Printf("\033]52;c;%s\a", encoded)
+		return nil
 	}
 }
 
@@ -472,14 +636,15 @@ var (
 	purple = lipgloss.Color("99")
 	orange = lipgloss.Color("208")
 
-	titleStyle     = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("15"))
-	subtitleStyle  = lipgloss.NewStyle().Foreground(lipgloss.Color("245"))
-	activeTabStyle = lipgloss.NewStyle().Foreground(blue).Bold(true).Background(lipgloss.Color("17")).Padding(0, 1)
-	tabStyle       = lipgloss.NewStyle().Foreground(lipgloss.Color("245")).Padding(0, 1)
-	labelStyle     = lipgloss.NewStyle().Foreground(lipgloss.Color("245"))
-	valueStyle     = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("15"))
-	sectionStyle   = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("15"))
-	mutedStyle     = lipgloss.NewStyle().Foreground(lipgloss.Color("245"))
-	helpStyle      = lipgloss.NewStyle().Foreground(lipgloss.Color("244"))
-	barStyle       = lipgloss.NewStyle().Foreground(blue)
+	titleStyle       = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("15"))
+	subtitleStyle    = lipgloss.NewStyle().Foreground(lipgloss.Color("245"))
+	activeTabStyle   = lipgloss.NewStyle().Foreground(blue).Bold(true).Background(lipgloss.Color("17")).Padding(0, 1)
+	tabStyle         = lipgloss.NewStyle().Foreground(lipgloss.Color("245")).Padding(0, 1)
+	labelStyle       = lipgloss.NewStyle().Foreground(lipgloss.Color("245"))
+	valueStyle       = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("15"))
+	sectionStyle     = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("15"))
+	mutedStyle       = lipgloss.NewStyle().Foreground(lipgloss.Color("245"))
+	helpStyle        = lipgloss.NewStyle().Foreground(lipgloss.Color("244"))
+	barStyle         = lipgloss.NewStyle().Foreground(blue)
+	selectedRowStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("15")).Background(lipgloss.Color("88")).Bold(true)
 )

--- a/internal/tui/tui_test.go
+++ b/internal/tui/tui_test.go
@@ -42,6 +42,9 @@ func TestRenderSmoke(t *testing.T) {
 	if strings.Contains(view, "↻ 30s") {
 		t.Fatalf("TUI toolbar must not render auto-refresh copy: %s", view)
 	}
+	if strings.Contains(view, "📅") {
+		t.Fatalf("TUI toolbar must not render date emoji: %s", view)
+	}
 }
 
 func TestRenderChinese(t *testing.T) {
@@ -176,6 +179,69 @@ func TestModelUsageTableOutputDoesNotIncludeReasoning(t *testing.T) {
 	}
 	if strings.Contains(view, "         250") {
 		t.Fatalf("model usage table output must not add reasoning tokens into output: %s", view)
+	}
+}
+
+func TestToolbarDateFormatsTodayWithoutRangeAndWeekWithRange(t *testing.T) {
+	loc := time.FixedZone("CST", 8*60*60)
+	payload := samplePayload()
+	payload.Period = query.PeriodToday
+	payload.Window = query.Window{Start: time.Date(2026, 5, 11, 0, 0, 0, 0, loc), End: time.Date(2026, 5, 12, 0, 0, 0, 0, loc)}
+	view := RenderWidth(payload, 160)
+	if !strings.Contains(view, "2026-05-11 CST") || strings.Contains(view, "～") || strings.Contains(view, "📅") {
+		t.Fatalf("today toolbar date should show date and zone only: %s", view)
+	}
+
+	payload.Period = query.PeriodThisWeek
+	payload.Window = query.Window{Start: time.Date(2026, 5, 4, 0, 0, 0, 0, loc), End: time.Date(2026, 5, 11, 0, 0, 0, 0, loc)}
+	view = RenderWidth(payload, 180)
+	if !strings.Contains(view, "2026-05-04 00:00 ～ 2026-05-11 00:00 CST") {
+		t.Fatalf("non-today toolbar date should show window range and zone: %s", view)
+	}
+}
+
+func TestThreadsBoxRendersSelectionAndScrollBar(t *testing.T) {
+	payload := samplePayload()
+	payload.Threads = []query.ThreadResult{
+		{ID: "thread-a", Name: "Login bug", Tool: "codex", Model: "gpt-5.4", Provider: "openai", Requests: 1, Events: 1, Usage: usage.TokenUsage{Input: 10}, CostUSD: 0.001},
+		{ID: "thread-b", Name: "Deploy", Tool: "claude", Model: "claude-sonnet", Provider: "unknown", Requests: 1, Events: 1, Usage: usage.TokenUsage{Input: 8}, CostUSD: 0.002},
+	}
+	view := RenderWidth(payload, 160)
+	for _, expected := range []string{"Threads", "ID", "Name", "Provider", "Login bug", "thread-a", "│"} {
+		if !strings.Contains(view, expected) {
+			t.Fatalf("threads box missing %q: %s", expected, view)
+		}
+	}
+}
+
+func TestThreadsKeyboardSelectionAndCopyStatus(t *testing.T) {
+	payload := samplePayload()
+	payload.Threads = []query.ThreadResult{
+		{ID: "thread-a", Name: "Login bug", Tool: "codex", Model: "gpt-5.4", Provider: "openai", Usage: usage.TokenUsage{Input: 10}},
+		{ID: "thread-b", Name: "Deploy", Tool: "claude", Model: "claude-sonnet", Provider: "unknown", Usage: usage.TokenUsage{Input: 8}},
+	}
+	m := NewModel(payload)
+	updated, _ := m.Update(keyMsg("t"))
+	m = updated.(model)
+	updated, _ = m.Update(keyMsg("j"))
+	m = updated.(model)
+	if m.threadCursor != 1 {
+		t.Fatalf("thread cursor = %d, want 1", m.threadCursor)
+	}
+	updated, cmd := m.Update(keyMsg("c"))
+	m = updated.(model)
+	if cmd == nil || !strings.Contains(m.copyStatus, "thread-b") {
+		t.Fatalf("copy should set status and emit command, status=%q cmd=%v", m.copyStatus, cmd)
+	}
+	updated, _ = m.Update(keyMsg("home"))
+	m = updated.(model)
+	if m.threadCursor != 0 {
+		t.Fatalf("home should move to first thread, got %d", m.threadCursor)
+	}
+	updated, _ = m.Update(keyMsg("end"))
+	m = updated.(model)
+	if m.threadCursor != 1 {
+		t.Fatalf("end should move to last thread, got %d", m.threadCursor)
 	}
 }
 

--- a/internal/usage/usage.go
+++ b/internal/usage/usage.go
@@ -40,14 +40,19 @@ func (u TokenUsage) Add(v TokenUsage) TokenUsage {
 }
 
 type UsageEvent struct {
-	ID        string     `json:"id"`
-	Timestamp time.Time  `json:"timestamp"`
-	Tool      Tool       `json:"tool"`
-	Model     string     `json:"model"`
-	Provider  string     `json:"provider"`
-	CWD       string     `json:"cwd,omitempty"`
-	Source    string     `json:"source,omitempty"`
-	Usage     TokenUsage `json:"usage"`
+	ID                 string     `json:"id"`
+	Timestamp          time.Time  `json:"timestamp"`
+	Tool               Tool       `json:"tool"`
+	Model              string     `json:"model"`
+	Provider           string     `json:"provider"`
+	CWD                string     `json:"cwd,omitempty"`
+	Source             string     `json:"source,omitempty"`
+	ThreadID           string     `json:"thread_id,omitempty"`
+	ThreadName         string     `json:"thread_name,omitempty"`
+	ThreadSource       string     `json:"thread_source,omitempty"`
+	ThreadCreatedAt    time.Time  `json:"thread_created_at,omitempty"`
+	ThreadLastActiveAt time.Time  `json:"thread_last_active_at,omitempty"`
+	Usage              TokenUsage `json:"usage"`
 }
 
 func Unknown(value string) string {


### PR DESCRIPTION
## Summary

- Fix TUI period display by removing the date emoji, showing only local date and timezone for `today`, and showing the actual query window plus timezone for non-`today` periods.
- Add `summary --threads` and a TUI Threads box with keyboard navigation, OSC52 ID copy, and per-thread usage/cost aggregation.
- Persist the implementation plan under `docs/superpowers/plans/2026-05-11-tui-period-threads-list.md` and document the new CLI/TUI behavior in both READMEs.

## Requirement Classification

- Type: feature + bugfix
- User-visible outcome: users can inspect matching local sessions/threads from CLI JSON/table/markdown and the TUI, while TUI period text is accurate and cleaner.
- Target platform(s): Go CLI and terminal TUI
- Scope assumptions: period semantics are unchanged; thread titles are derived only from local logs/index files; no network upload or model-generated title creation.

## Acceptance Criteria

- [x] Criteria are written before implementation starts.
- [x] Each criterion maps to unit test coverage where practical.
- [x] Each criterion maps to CLI/manual/platform evidence where relevant.
- [x] At least one failure or edge case is covered, or a reason is documented.

## Changed Areas

- `internal/sources`: attach thread metadata for Codex, Claude, and Gemini; Codex now prefers `.codex/session_index.jsonl` `thread_name` and filters injected/non-title messages.
- `internal/query` / `internal/report` / `internal/cli`: aggregate `ThreadResult` rows and expose them behind `summary --threads`.
- `internal/tui`: render the Threads box with focus, cursor-driven scrolling, scrollbar, and OSC52 copy feedback; fix period display.
- `README.md`, `README.zh-CN.md`, and `docs/superpowers/plans/2026-05-11-tui-period-threads-list.md`: document the plan and user-facing behavior.

## Release Decision

- Release required after merge: this is feature and bugfix work.

## TDD / Test Evidence

- Test/sensor added before implementation: source/query/report/TUI/CLI tests were added for thread metadata, aggregation, output shape, date display, and keyboard interactions.
- Unit tests: `go test ./internal/sources ./internal/query ./internal/report ./internal/tui ./internal/cli`
- CLI/manual/platform evidence: `go run ./cmd/aitok summary --period today --tool codex --threads --format json --no-version-check` confirmed the current Codex thread name matches `.codex/session_index.jsonl`.
- Failure and edge cases covered: Codex custom/UI titles, explicit AI title events, first real user message fallback, cwd fallback, injected IDE context, `<turn_aborted>`, `summary: none`, same-thread aggregation, omitted `threads` when flag is not passed, TUI no emoji/today/non-today display, scrolling and copy state.
- Acceptance criteria evidence map: source adapter criteria via `internal/sources` tests; query/report/JSON criteria via `internal/query`, `internal/report`, and `internal/cli` tests; TUI criteria via `internal/tui` tests and CLI smoke.

## Validation

- [x] `make check`
- [x] `make test`
- [x] `make test-harness`
- [x] `make build`
- [x] Commit message follows `go run ./tools/commitlint --edit <commit-msg-file>`
- Skipped validation and reason: none

## Risk and Rollback

- Risk: historical Codex logs without `session_index.jsonl` may still fall back to cwd basename or short ID when no reliable title is present.
- Rollback: revert commit `107b7da` to remove the threads feature and TUI period changes.
- Residual risk: terminal OSC52 clipboard support varies by terminal; unsupported terminals still show the selected ID and copy status without breaking navigation.
