### PR TITLE
[codex] Add interactive pricing configuration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,10 +43,11 @@ Out of scope unless explicitly requested:
 - Harness-only tests: `make test-harness`
 - Vet: `make vet`
 - Build: `make build`
+- Run CLI with project-local Go cache: `make run ARGS="summary --period today"`
 - Full local validation: `make validate`
 - PR metadata check: `make validate-pr-body`
 - Commit message check: `make commitlint COMMIT_MSG_FILE=<commit-msg-file>`
-- Run CLI directly: `go run ./cmd/aitok summary --period today`
+- Avoid raw `go run` in sandboxed agent sessions; use `make run ARGS="..."` so Go build/cache output stays under `.cache/aitok`.
 
 ## 3) Iteration Self-Constraint Protocol
 
@@ -108,7 +109,7 @@ Before every product or harness iteration, do a short internal review:
 - Documentation or harness only: `make check`, `make test-harness`, and `make validate-pr-body` when PR rules changed.
 - Source adapter: `make test`, including normal, empty directory, malformed JSONL, missing field, and duplicate event cases.
 - Query/report: `make test`, covering period windows, filters, grouping, and stable JSON/Markdown output.
-- CLI/TUI: `make test`, `make build`, and when useful `go run ./cmd/aitok doctor` or `summary` smoke.
+- CLI/TUI: `make test`, `make build`, and when useful `make run ARGS="doctor"` or `make run ARGS="summary --period today"` smoke.
 - Dependencies, CI, or release config: `make validate`, with binary-size/offline/supply-chain impact noted.
 
 ## 7) CI and Submission Protocol

--- a/AGENTS.zh-CN.md
+++ b/AGENTS.zh-CN.md
@@ -43,10 +43,11 @@
 - Harness-only 测试：`make test-harness`
 - Vet：`make vet`
 - 构建：`make build`
+- 使用项目本地 Go cache 运行 CLI：`make run ARGS="summary --period today"`
 - 完整本地验证：`make validate`
 - PR 元数据校验：`make validate-pr-body`
 - 提交消息检查：`make commitlint COMMIT_MSG_FILE=<commit-msg-file>`
-- 直接运行 CLI：`go run ./cmd/aitok summary --period today`
+- 沙箱内 agent session 避免直接使用 `go run`；使用 `make run ARGS="..."`，让 Go build/cache 输出固定落在 `.cache/aitok`。
 
 ## 3) 迭代前自我约束流程
 
@@ -108,7 +109,7 @@
 - 文档或 Harness only：`make check`、`make test-harness`，PR 规则变化时加 `make validate-pr-body`。
 - Source adapter：`make test`，并覆盖正常、空目录、损坏 JSONL、缺字段、重复事件。
 - Query/report：`make test`，并覆盖时间窗口、过滤、分组、JSON/Markdown 稳定输出。
-- CLI/TUI：`make test`、`make build`，必要时跑 `go run ./cmd/aitok doctor` 或 `summary` smoke。
+- CLI/TUI：`make test`、`make build`，必要时跑 `make run ARGS="doctor"` 或 `make run ARGS="summary --period today"` smoke。
 - 依赖、CI、发布配置：`make validate`，并说明体积/离线/供应链影响。
 
 ## 7) CI 和提交流程

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ GOCACHE ?= $(AITOK_CACHE_DIR)/go-build
 GOMODCACHE ?= $(AITOK_CACHE_DIR)/go-mod
 COMMIT_MSG_FILE ?= .git/COMMIT_EDITMSG
 
-.PHONY: setup check test test-harness vet build validate validate-pr-body commitlint
+.PHONY: setup check test test-harness vet build run validate validate-pr-body commitlint
 
 setup:
 	git config core.hooksPath .githooks
@@ -24,6 +24,9 @@ vet:
 
 build:
 	GOCACHE=$(GOCACHE) GOMODCACHE=$(GOMODCACHE) $(GO) build ./cmd/aitok
+
+run:
+	GOCACHE=$(GOCACHE) GOMODCACHE=$(GOMODCACHE) $(GO) run ./cmd/aitok $(ARGS)
 
 validate-pr-body:
 	GOCACHE=$(GOCACHE) GOMODCACHE=$(GOMODCACHE) $(GO) run ./tools/validate-pr-body

--- a/README.md
+++ b/README.md
@@ -31,6 +31,12 @@ For local development:
 go install ./cmd/aitok
 ```
 
+To run the CLI from a checkout without writing Go build cache into `~/Library/Caches`, use the project Makefile wrapper:
+
+```bash
+make run ARGS="summary --period today"
+```
+
 `aitok` checks GitHub release metadata at most once every 24 hours before a command runs. If a newer version exists, it prints an upgrade prompt to stderr based on the detected install method. The check does not upload usage data, does not read logs, and can be skipped with `--no-version-check` or `AITOK_NO_VERSION_CHECK=1`.
 
 ## Usage
@@ -122,7 +128,27 @@ Save this as `~/.aitok/pricing.json`, or pass a file explicitly:
 aitok summary --pricing ./pricing.json --format json
 ```
 
-Prices are USD per 1M tokens. `cache_hit_usd_per_mtok` is cache read pricing. `cache_make_usd_per_mtok` is the default cache write price, and `cache_make_1h_usd_per_mtok` can override one-hour cache write pricing when a source reports that split. Models with provider prompt tiers can also set `prompt_threshold_tokens` plus `above_threshold_*_usd_per_mtok` fields. Reasoning tokens are charged as output tokens. `multiplier` defaults to `1`.
+You can also create or update the local override from a terminal Q/A flow:
+
+```bash
+aitok pricing configure
+```
+
+The command writes `~/.aitok/pricing.json` and asks numbered questions for a model match, provider/auth label, input/output/cache pricing, and multiplier. For scripted setup, pass the values directly:
+
+```bash
+aitok pricing configure \
+  --model gpt-5.4 \
+  --provider team-a \
+  --input-usd-per-mtok 2 \
+  --output-usd-per-mtok 20 \
+  --cache-hit-usd-per-mtok 0.2 \
+  --cache-make-usd-per-mtok 2.5 \
+  --cache-make-1h-usd-per-mtok 0 \
+  --multiplier 1
+```
+
+Prices are USD per 1M tokens. `provider` is a local provider/auth label from tool logs, such as Codex `model_provider` or Gemini `auth_type`; it must not be a raw API key. Use different local labels for different accounts or API-key-backed routes when the upstream tool logs expose those labels. `cache_hit_usd_per_mtok` is cache read pricing. `cache_make_usd_per_mtok` is the default cache write price, and `cache_make_1h_usd_per_mtok` can override one-hour cache write pricing when a source reports that split. Models with provider prompt tiers can also set `prompt_threshold_tokens` plus `above_threshold_*_usd_per_mtok` fields. Reasoning tokens are reported separately and are not charged as billable output by the offline estimate. `multiplier` defaults to `1`.
 
 To check whether local usage contains models that are not covered by the offline catalog or your override file:
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -31,6 +31,12 @@ go install github.com/MagnumGoYB/aitok/cmd/aitok@latest
 go install ./cmd/aitok
 ```
 
+如果要在 checkout 中直接运行 CLI，并避免 Go build cache 写到 `~/Library/Caches`，使用仓库 Makefile 包装：
+
+```bash
+make run ARGS="summary --period today"
+```
+
 `aitok` 会在命令执行前最多每 24 小时检查一次 GitHub release 元数据。如果发现新版本，会根据检测到的安装方式把升级提示输出到 stderr。该检查不会上传用量数据，不会读取日志，也可以通过 `--no-version-check` 或 `AITOK_NO_VERSION_CHECK=1` 跳过。
 
 ## 使用
@@ -122,7 +128,27 @@ Thread 行包含 ID、名称、tool、model、provider、Token 用量、requests
 aitok summary --pricing ./pricing.json --format json
 ```
 
-价格单位是 USD / 1M tokens。`cache_hit_usd_per_mtok` 表示 cache read 价格。`cache_make_usd_per_mtok` 表示默认 cache write 价格；当数据源能区分一小时缓存写入时，可用 `cache_make_1h_usd_per_mtok` 单独覆盖。存在 provider prompt 分层价的模型还可以配置 `prompt_threshold_tokens` 和 `above_threshold_*_usd_per_mtok` 字段。Reasoning tokens 按 output tokens 计费。`multiplier` 默认是 `1`。
+也可以直接用终端 Q/A 问答创建或更新本地覆盖：
+
+```bash
+aitok pricing configure
+```
+
+该命令会写入 `~/.aitok/pricing.json`，并通过编号问题依次询问 model match、provider/auth label、input/output/cache 价格和 multiplier。脚本化配置时也可以直接传参：
+
+```bash
+aitok pricing configure \
+  --model gpt-5.4 \
+  --provider team-a \
+  --input-usd-per-mtok 2 \
+  --output-usd-per-mtok 20 \
+  --cache-hit-usd-per-mtok 0.2 \
+  --cache-make-usd-per-mtok 2.5 \
+  --cache-make-1h-usd-per-mtok 0 \
+  --multiplier 1
+```
+
+价格单位是 USD / 1M tokens。`provider` 是工具日志里的本地 provider/auth 标签，例如 Codex `model_provider` 或 Gemini `auth_type`；这里不能填写真实 API Key。如果上游工具日志能暴露不同账号或 API-key 路由对应的本地标签，就用这些标签区分不同价格。`cache_hit_usd_per_mtok` 表示 cache read 价格。`cache_make_usd_per_mtok` 表示默认 cache write 价格；当数据源能区分一小时缓存写入时，可用 `cache_make_1h_usd_per_mtok` 单独覆盖。存在 provider prompt 分层价的模型还可以配置 `prompt_threshold_tokens` 和 `above_threshold_*_usd_per_mtok` 字段。Reasoning tokens 单独统计，离线估算不会把它当作 billable output 计费。`multiplier` 默认是 `1`。
 
 如需检查本地用量中是否存在离线价格表或本地覆盖文件无法匹配的模型：
 

--- a/docs/iteration-notes/2026-05-09-agent-cost-governance.md
+++ b/docs/iteration-notes/2026-05-09-agent-cost-governance.md
@@ -118,12 +118,31 @@ Validation:
 
 ## Tooling And Cache Decision
 
+## 2026-05-14 Interactive Pricing Configuration
+
+Follow-up feature: local pricing overrides can now be created from the terminal with `aitok pricing configure`.
+
+Key contract:
+
+- The command writes `~/.aitok/pricing.json` using `0600` permissions and supports both numbered terminal Q/A prompts and scripted flag-only setup.
+- Matching remains `model match + provider/auth label`; raw API keys must not be entered, stored, displayed, hashed, or fingerprinted.
+- Use provider/auth labels already present in local tool logs, for example Codex `model_provider` or Gemini `auth_type`, when a user wants different prices for different account or API-key-backed routes.
+- JSON mode keeps prompts on stderr and returns the final machine-readable payload on stdout.
+
+Validation for this slice:
+
+- `make check`
+- `make test`
+- `make build`
+- CLI smoke with `make run ARGS="--home /private/tmp/aitok-pricing-smoke --no-version-check pricing configure --format json"`
+
 Earlier validation used `/tmp` or `/private/tmp` for Go caches only because the sandbox denied Go default cache writes under `~/Library/Caches`.
 
 The durable project-local direction is:
 
 - keep validation caches under `.cache/aitok`
 - use Makefile targets instead of ad-hoc temp commands
+- use `make run ARGS="..."` for CLI smoke from a checkout instead of raw `go run`
 - run `make setup` once per checkout to enable `.githooks/commit-msg`
 - run commit message validation through `make commitlint COMMIT_MSG_FILE=<commit-msg-file>`
 - let PR CI validate the latest PR commit message so contributors who did not run local setup are still covered

--- a/docs/zh-CN/iteration-notes/2026-05-09-agent-cost-governance.md
+++ b/docs/zh-CN/iteration-notes/2026-05-09-agent-cost-governance.md
@@ -118,12 +118,31 @@
 
 ## 工具和缓存决策
 
+## 2026-05-14 交互式价格配置
+
+后续功能：现在可以通过 `aitok pricing configure` 在终端里创建本地价格覆盖。
+
+关键合同：
+
+- 命令写入 `~/.aitok/pricing.json`，文件权限为 `0600`，同时支持终端编号 Q/A 问答和可脚本化的纯 flag 配置方式。
+- 匹配维度仍然是 `model match + provider/auth label`；不能输入、存储、展示、哈希或指纹化真实 API Key。
+- 用户想为不同账号或 API-key 路由设置不同价格时，只能使用本地工具日志中已有的 provider/auth 标签，例如 Codex `model_provider` 或 Gemini `auth_type`。
+- JSON 模式下交互提示走 stderr，stdout 只输出最终机器可读 payload。
+
+本切片验证：
+
+- `make check`
+- `make test`
+- `make build`
+- 使用 `make run ARGS="--home /private/tmp/aitok-pricing-smoke --no-version-check pricing configure --format json"` 做 CLI smoke
+
 早期验证使用 `/tmp` 或 `/private/tmp` 存 Go cache，只是因为沙箱拒绝写入 Go 默认的 `~/Library/Caches`。
 
 长期项目内约定是：
 
 - 验证缓存放在 `.cache/aitok`
 - 优先使用 Makefile 目标，不使用临时拼接命令作为项目工具
+- checkout 内 CLI smoke 使用 `make run ARGS="..."`，不要直接裸跑 `go run`
 - 每个 checkout 运行一次 `make setup`，启用 `.githooks/commit-msg`
 - 提交信息校验使用 `make commitlint COMMIT_MSG_FILE=<commit-msg-file>`
 - PR CI 校验 PR 最新提交消息，所以没有运行本地 setup 的贡献者也会被覆盖

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"bufio"
 	"context"
 	"encoding/json"
 	"errors"
@@ -9,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -26,6 +28,7 @@ import (
 type App struct {
 	Out          io.Writer
 	Err          io.Writer
+	In           io.Reader
 	Now          func() time.Time
 	VersionCheck func(context.Context, VersionCheckOptions) error
 	Update       func(context.Context, UpdateOptions) error
@@ -73,6 +76,9 @@ func New(app App) *cobra.Command {
 	}
 	if app.Err == nil {
 		app.Err = io.Discard
+	}
+	if app.In == nil {
+		app.In = os.Stdin
 	}
 	if app.Now == nil {
 		app.Now = time.Now
@@ -137,6 +143,41 @@ func New(app App) *cobra.Command {
 		Use:   "pricing",
 		Short: "Inspect offline pricing coverage",
 	}
+	var priceInput pricingConfigInput
+	pricingConfigure := &cobra.Command{
+		Use:   "configure",
+		Short: "Configure local offline pricing overrides",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			promptOut := app.Out
+			if f.format == "json" {
+				promptOut = app.Err
+			}
+			configured, path, err := configurePricing(app.In, promptOut, resolveHome(f.home), priceInput)
+			if err != nil {
+				return err
+			}
+			if f.format == "json" {
+				encoder := json.NewEncoder(app.Out)
+				encoder.SetIndent("", "  ")
+				return encoder.Encode(map[string]any{
+					"path":  path,
+					"price": configured,
+				})
+			}
+			fmt.Fprintf(app.Out, "Pricing override saved: %s\n", path)
+			fmt.Fprintf(app.Out, "Model match: %s\nProvider/auth label: %s\n", configured.Match, usage.Unknown(configured.Provider))
+			return nil
+		},
+	}
+	pricingConfigure.Flags().StringVar(&priceInput.Match, "model", "", "model match substring, for example gpt-5.4")
+	pricingConfigure.Flags().StringVar(&priceInput.Provider, "provider", "", "provider/auth label from local logs; do not enter a raw API key")
+	pricingConfigure.Flags().Float64Var(&priceInput.InputUSDPerMTok, "input-usd-per-mtok", -1, "input price in USD per 1M tokens")
+	pricingConfigure.Flags().Float64Var(&priceInput.OutputUSDPerMTok, "output-usd-per-mtok", -1, "output price in USD per 1M tokens")
+	pricingConfigure.Flags().Float64Var(&priceInput.CacheHitUSDPerMTok, "cache-hit-usd-per-mtok", -1, "cache read price in USD per 1M tokens")
+	pricingConfigure.Flags().Float64Var(&priceInput.CacheMakeUSDPerMTok, "cache-make-usd-per-mtok", -1, "cache write price in USD per 1M tokens")
+	pricingConfigure.Flags().Float64Var(&priceInput.CacheMake1hUSDPerMTok, "cache-make-1h-usd-per-mtok", -1, "one-hour cache write price in USD per 1M tokens")
+	pricingConfigure.Flags().Float64Var(&priceInput.Multiplier, "multiplier", -1, "local multiplier; defaults to 1")
+	pricingConfigure.Flags().StringVar(&f.format, "format", "table", "format: table or json")
 	pricingAudit := &cobra.Command{
 		Use:   "audit",
 		Short: "Report local usage events without matching prices",
@@ -149,7 +190,7 @@ func New(app App) *cobra.Command {
 		},
 	}
 	addQueryFlags(pricingAudit, f)
-	pricingCmd.AddCommand(pricingAudit)
+	pricingCmd.AddCommand(pricingConfigure, pricingAudit)
 
 	budgetCmd := &cobra.Command{
 		Use:   "budget",
@@ -480,6 +521,147 @@ func pricingSkeleton(items []report.PricingAuditResult) string {
 	}
 	b.WriteString("\n  ]\n}\n")
 	return b.String()
+}
+
+type pricingConfigInput struct {
+	Match                 string
+	Provider              string
+	InputUSDPerMTok       float64
+	OutputUSDPerMTok      float64
+	CacheHitUSDPerMTok    float64
+	CacheMakeUSDPerMTok   float64
+	CacheMake1hUSDPerMTok float64
+	Multiplier            float64
+}
+
+func configurePricing(in io.Reader, out io.Writer, home string, input pricingConfigInput) (pricing.ModelPrice, string, error) {
+	reader := bufio.NewReader(in)
+	interactive := pricingInputNeedsPrompt(input)
+	var err error
+	question := 1
+	input.Match, err = promptString(reader, out, interactive && strings.TrimSpace(input.Match) == "", &question, "Which model should this price match?", "Example: gpt-5.4 or claude-sonnet-4.", input.Match)
+	if err != nil {
+		return pricing.ModelPrice{}, "", err
+	}
+	input.Provider, err = promptString(reader, out, interactive && strings.TrimSpace(input.Provider) == "", &question, "Which provider/auth label should this apply to?", "Use a local label from logs, not a raw API key. Example: openai, bcb, team-a, oauth.", input.Provider)
+	if err != nil {
+		return pricing.ModelPrice{}, "", err
+	}
+	input.InputUSDPerMTok, err = promptFloat(reader, out, interactive && input.InputUSDPerMTok < 0, &question, "What is the input price in USD per 1M tokens?", "Enter 0 if this price does not apply.", input.InputUSDPerMTok)
+	if err != nil {
+		return pricing.ModelPrice{}, "", err
+	}
+	input.OutputUSDPerMTok, err = promptFloat(reader, out, interactive && input.OutputUSDPerMTok < 0, &question, "What is the output price in USD per 1M tokens?", "Enter 0 if this price does not apply.", input.OutputUSDPerMTok)
+	if err != nil {
+		return pricing.ModelPrice{}, "", err
+	}
+	input.CacheHitUSDPerMTok, err = promptFloat(reader, out, interactive && input.CacheHitUSDPerMTok < 0, &question, "What is the cache read price in USD per 1M tokens?", "Enter 0 if this price does not apply.", input.CacheHitUSDPerMTok)
+	if err != nil {
+		return pricing.ModelPrice{}, "", err
+	}
+	input.CacheMakeUSDPerMTok, err = promptFloat(reader, out, interactive && input.CacheMakeUSDPerMTok < 0, &question, "What is the cache write price in USD per 1M tokens?", "Blank uses 0; enter the input price if cache writes are billed like input tokens.", input.CacheMakeUSDPerMTok)
+	if err != nil {
+		return pricing.ModelPrice{}, "", err
+	}
+	input.CacheMake1hUSDPerMTok, err = promptFloat(reader, out, interactive && input.CacheMake1hUSDPerMTok < 0, &question, "What is the one-hour cache write price in USD per 1M tokens?", "Blank uses the default cache write price.", input.CacheMake1hUSDPerMTok)
+	if err != nil {
+		return pricing.ModelPrice{}, "", err
+	}
+	input.Multiplier, err = promptFloat(reader, out, interactive && input.Multiplier < 0, &question, "What multiplier should be applied?", "Blank uses 1. Use this for local markup/discount adjustments.", input.Multiplier)
+	if err != nil {
+		return pricing.ModelPrice{}, "", err
+	}
+	price := pricing.ModelPrice{
+		Match:                 strings.TrimSpace(input.Match),
+		Provider:              strings.TrimSpace(input.Provider),
+		InputUSDPerMTok:       zeroIfUnset(input.InputUSDPerMTok),
+		OutputUSDPerMTok:      zeroIfUnset(input.OutputUSDPerMTok),
+		CacheHitUSDPerMTok:    zeroIfUnset(input.CacheHitUSDPerMTok),
+		CacheMakeUSDPerMTok:   zeroIfUnset(input.CacheMakeUSDPerMTok),
+		CacheMake1hUSDPerMTok: zeroIfUnset(input.CacheMake1hUSDPerMTok),
+		Multiplier:            input.Multiplier,
+	}
+	if price.Multiplier < 0 {
+		price.Multiplier = 1
+	}
+	path, err := pricing.SaveUserPrice(home, price)
+	if err != nil {
+		return pricing.ModelPrice{}, "", err
+	}
+	return price, path, nil
+}
+
+func pricingInputNeedsPrompt(input pricingConfigInput) bool {
+	return strings.TrimSpace(input.Match) == "" ||
+		strings.TrimSpace(input.Provider) == "" ||
+		input.InputUSDPerMTok < 0 ||
+		input.OutputUSDPerMTok < 0 ||
+		input.CacheHitUSDPerMTok < 0 ||
+		input.CacheMakeUSDPerMTok < 0 ||
+		input.CacheMake1hUSDPerMTok < 0 ||
+		input.Multiplier < 0
+}
+
+func promptString(reader *bufio.Reader, out io.Writer, shouldPrompt bool, question *int, label string, hint string, value string) (string, error) {
+	if !shouldPrompt {
+		return value, nil
+	}
+	if err := writeQuestion(out, question, label, hint); err != nil {
+		return "", err
+	}
+	value, err := reader.ReadString('\n')
+	if err != nil && !errors.Is(err, io.EOF) {
+		return "", err
+	}
+	return strings.TrimSpace(value), nil
+}
+
+func promptFloat(reader *bufio.Reader, out io.Writer, shouldPrompt bool, question *int, label string, hint string, value float64) (float64, error) {
+	if !shouldPrompt {
+		return value, nil
+	}
+	if err := writeQuestion(out, question, label, hint); err != nil {
+		return 0, err
+	}
+	raw, err := reader.ReadString('\n')
+	if err != nil && !errors.Is(err, io.EOF) {
+		return 0, err
+	}
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		if strings.Contains(strings.ToLower(label), "multiplier") {
+			return 1, nil
+		}
+		return 0, nil
+	}
+	parsed, err := strconv.ParseFloat(raw, 64)
+	if err != nil {
+		return 0, fmt.Errorf("%s must be a number", label)
+	}
+	return parsed, nil
+}
+
+func writeQuestion(out io.Writer, question *int, label string, hint string) error {
+	if _, err := fmt.Fprintf(out, "Q%d: %s\n", *question, label); err != nil {
+		return err
+	}
+	if hint != "" {
+		if _, err := fmt.Fprintf(out, "   %s\n", hint); err != nil {
+			return err
+		}
+	}
+	if _, err := fmt.Fprint(out, "A: "); err != nil {
+		return err
+	}
+	*question = *question + 1
+	return nil
+}
+
+func zeroIfUnset(value float64) float64 {
+	if value < 0 {
+		return 0
+	}
+	return value
 }
 
 func buildDoctor(ctx context.Context, f *flags, now time.Time) (report.DoctorPayload, error) {

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -313,6 +313,120 @@ func TestSetupGeminiDryRunCommand(t *testing.T) {
 	}
 }
 
+func TestPricingConfigureCommandWritesInteractiveOverride(t *testing.T) {
+	home := t.TempDir()
+	var out bytes.Buffer
+	cmd := New(App{
+		Out: &out,
+		In:  strings.NewReader("gpt-5.4\nteam-a\n2\n20\n0.2\n2.5\n\n1.25\n"),
+	})
+	cmd.SetArgs([]string{"--home", home, "pricing", "configure"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out.String(), "Q1: Which model should this price match?") || !strings.Contains(out.String(), "A: ") || !strings.Contains(out.String(), "Pricing override saved") || !strings.Contains(out.String(), "Provider/auth label: team-a") {
+		t.Fatalf("interactive configure output missing save summary: %s", out.String())
+	}
+	data, err := os.ReadFile(filepath.Join(home, ".aitok", "pricing.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := string(data); !strings.Contains(got, `"match": "gpt-5.4"`) || !strings.Contains(got, `"provider": "team-a"`) || !strings.Contains(got, `"multiplier": 1.25`) {
+		t.Fatalf("pricing config not written correctly: %s", got)
+	}
+}
+
+func TestPricingConfigureCommandSupportsFlagOnlyJSON(t *testing.T) {
+	home := t.TempDir()
+	var out bytes.Buffer
+	cmd := New(App{Out: &out, In: strings.NewReader("")})
+	cmd.SetArgs([]string{
+		"--home", home,
+		"pricing", "configure",
+		"--model", "gpt-5.4",
+		"--provider", "team-b",
+		"--input-usd-per-mtok", "7",
+		"--output-usd-per-mtok", "70",
+		"--cache-hit-usd-per-mtok", "0.7",
+		"--cache-make-usd-per-mtok", "7",
+		"--cache-make-1h-usd-per-mtok", "8",
+		"--multiplier", "1",
+		"--format", "json",
+	})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(out.String(), "Q1:") {
+		t.Fatalf("flag-only json configure should not print prompts: %s", out.String())
+	}
+	var payload struct {
+		Path  string `json:"path"`
+		Price struct {
+			Match    string `json:"match"`
+			Provider string `json:"provider"`
+		} `json:"price"`
+	}
+	if err := json.Unmarshal(out.Bytes(), &payload); err != nil {
+		t.Fatalf("configure json should be valid: %v\n%s", err, out.String())
+	}
+	if payload.Path == "" || payload.Price.Match != "gpt-5.4" || payload.Price.Provider != "team-b" {
+		t.Fatalf("unexpected configure payload: %+v", payload)
+	}
+}
+
+func TestPricingConfigureJSONKeepsPromptsOffStdout(t *testing.T) {
+	home := t.TempDir()
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd := New(App{
+		Out: &out,
+		Err: &stderr,
+		In:  strings.NewReader("gpt-5.4\nteam-json\n2\n20\n0.2\n2.5\n\n1\n"),
+	})
+	cmd.SetArgs([]string{"--home", home, "pricing", "configure", "--format", "json"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(out.String(), "Q1:") {
+		t.Fatalf("json stdout should not contain prompts: %s", out.String())
+	}
+	if !strings.Contains(stderr.String(), "Q1: Which model should this price match?") {
+		t.Fatalf("interactive prompts should be written to stderr for json mode: %s", stderr.String())
+	}
+	var payload struct {
+		Price struct {
+			Provider string `json:"provider"`
+		} `json:"price"`
+	}
+	if err := json.Unmarshal(out.Bytes(), &payload); err != nil {
+		t.Fatalf("json stdout should remain machine-readable: %v\n%s", err, out.String())
+	}
+	if payload.Price.Provider != "team-json" {
+		t.Fatalf("unexpected json payload: %s", out.String())
+	}
+}
+
+func TestPricingConfigureRejectsRawAPIKeyProvider(t *testing.T) {
+	home := t.TempDir()
+	cmd := New(App{Out: io.Discard, In: strings.NewReader("")})
+	cmd.SetArgs([]string{
+		"--home", home,
+		"pricing", "configure",
+		"--model", "gpt-5.4",
+		"--provider", "sk-test-secret",
+		"--input-usd-per-mtok", "1",
+		"--output-usd-per-mtok", "1",
+		"--cache-hit-usd-per-mtok", "0",
+		"--cache-make-usd-per-mtok", "1",
+		"--cache-make-1h-usd-per-mtok", "1",
+		"--multiplier", "1",
+	})
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "not a raw API key") {
+		t.Fatalf("err = %v, want raw API key rejection", err)
+	}
+}
+
 func TestPricingAuditReportsUnpricedModels(t *testing.T) {
 	home := t.TempDir()
 	writeFixture(t, filepath.Join(home, ".codex", "sessions", "2026", "05", "08", "rollout.jsonl"),

--- a/internal/pricing/config.go
+++ b/internal/pricing/config.go
@@ -1,0 +1,102 @@
+package pricing
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+func UserConfigPath(home string) string {
+	return filepath.Join(home, userConfigPath)
+}
+
+func LoadUserConfig(home string) (Catalog, error) {
+	path := UserConfigPath(home)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return Catalog{}, nil
+		}
+		return Catalog{}, err
+	}
+	var catalog Catalog
+	if err := json.Unmarshal(data, &catalog); err != nil {
+		return Catalog{}, err
+	}
+	return catalog, nil
+}
+
+func SaveUserPrice(home string, price ModelPrice) (string, error) {
+	if err := ValidateUserPrice(price); err != nil {
+		return "", err
+	}
+	catalog, err := LoadUserConfig(home)
+	if err != nil {
+		return "", err
+	}
+	price.Source = ""
+	catalog.upsert(price)
+	path := UserConfigPath(home)
+	if err := writeUserConfig(path, catalog); err != nil {
+		return "", err
+	}
+	return path, nil
+}
+
+func ValidateUserPrice(price ModelPrice) error {
+	if strings.TrimSpace(price.Match) == "" {
+		return fmt.Errorf("model match is required")
+	}
+	if strings.Contains(strings.ToLower(price.Provider), "sk-") {
+		return fmt.Errorf("provider must be a local provider/auth label, not a raw API key")
+	}
+	if price.InputUSDPerMTok < 0 || price.OutputUSDPerMTok < 0 || price.CacheHitUSDPerMTok < 0 || price.CacheMakeUSDPerMTok < 0 || price.CacheMake1hUSDPerMTok < 0 {
+		return fmt.Errorf("prices must be greater than or equal to 0")
+	}
+	if price.InputUSDPerMTok == 0 && price.OutputUSDPerMTok == 0 && price.CacheHitUSDPerMTok == 0 && price.CacheMakeUSDPerMTok == 0 && price.CacheMake1hUSDPerMTok == 0 {
+		return fmt.Errorf("at least one price must be greater than 0")
+	}
+	if price.Multiplier < 0 {
+		return fmt.Errorf("multiplier must be greater than or equal to 0")
+	}
+	if price.PromptThresholdTokens < 0 {
+		return fmt.Errorf("prompt threshold must be greater than or equal to 0")
+	}
+	return nil
+}
+
+func writeUserConfig(path string, catalog Catalog) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(catalog, "", "  ")
+	if err != nil {
+		return err
+	}
+	data = append(data, '\n')
+	tmp, err := os.CreateTemp(filepath.Dir(path), ".pricing-*.json")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmp.Name()
+	defer os.Remove(tmpPath)
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	if err := os.Chmod(tmpPath, 0o600); err != nil {
+		return err
+	}
+	oldData, readErr := os.ReadFile(path)
+	if readErr == nil && bytes.Equal(oldData, data) {
+		return os.Remove(tmpPath)
+	}
+	return os.Rename(tmpPath, path)
+}

--- a/internal/pricing/pricing.go
+++ b/internal/pricing/pricing.go
@@ -1,10 +1,6 @@
 package pricing
 
 import (
-	"encoding/json"
-	"errors"
-	"os"
-	"path/filepath"
 	"sort"
 	"strings"
 
@@ -43,16 +39,8 @@ type Cost struct {
 
 func Load(home string) (Catalog, error) {
 	catalog := DefaultCatalog()
-	path := filepath.Join(home, userConfigPath)
-	data, err := os.ReadFile(path)
+	user, err := LoadUserConfig(home)
 	if err != nil {
-		if errors.Is(err, os.ErrNotExist) {
-			return catalog, nil
-		}
-		return Catalog{}, err
-	}
-	var user Catalog
-	if err := json.Unmarshal(data, &user); err != nil {
 		return Catalog{}, err
 	}
 	for _, price := range user.Models {

--- a/internal/pricing/pricing_test.go
+++ b/internal/pricing/pricing_test.go
@@ -4,6 +4,7 @@ import (
 	"math"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/MagnumGoYB/aitok/internal/usage"
@@ -154,6 +155,68 @@ func TestLoadCatalogMergesUserConfigOverDefaults(t *testing.T) {
 	}
 }
 
+func TestSaveUserPriceUpsertsProviderSpecificOverride(t *testing.T) {
+	home := t.TempDir()
+	if _, err := SaveUserPrice(home, ModelPrice{
+		Match:            "gpt-5.4",
+		Provider:         "team-a",
+		InputUSDPerMTok:  2,
+		OutputUSDPerMTok: 20,
+		Multiplier:       1,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := SaveUserPrice(home, ModelPrice{
+		Match:            "gpt-5.4",
+		Provider:         "team-b",
+		InputUSDPerMTok:  8,
+		OutputUSDPerMTok: 80,
+		Multiplier:       1,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	catalog, err := Load(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	teamA := catalog.CostFor(usage.UsageEvent{
+		Model:    "gpt-5.4",
+		Provider: "team-a",
+		Usage:    usage.TokenUsage{Input: 1_000_000},
+	})
+	teamB := catalog.CostFor(usage.UsageEvent{
+		Model:    "gpt-5.4",
+		Provider: "team-b",
+		Usage:    usage.TokenUsage{Input: 1_000_000},
+	})
+	if teamA.USD != 2 || teamB.USD != 8 {
+		t.Fatalf("provider-specific overrides not applied: team-a=%+v team-b=%+v", teamA, teamB)
+	}
+	data, err := os.ReadFile(UserConfigPath(home))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info, err := os.Stat(UserConfigPath(home)); err != nil {
+		t.Fatal(err)
+	} else if mode := info.Mode().Perm(); mode != 0o600 {
+		t.Fatalf("pricing config mode = %o, want 600", mode)
+	}
+	if got := string(data); !containsAll(got, `"provider": "team-a"`, `"provider": "team-b"`) {
+		t.Fatalf("pricing config missing provider overrides: %s", got)
+	}
+}
+
+func TestSaveUserPriceRejectsRawAPIKeyProvider(t *testing.T) {
+	_, err := SaveUserPrice(t.TempDir(), ModelPrice{
+		Match:           "gpt-5.4",
+		Provider:        "sk-test-secret",
+		InputUSDPerMTok: 1,
+	})
+	if err == nil {
+		t.Fatal("expected raw API key provider to be rejected")
+	}
+}
+
 func TestLoadIgnoresMissingUserConfig(t *testing.T) {
 	catalog, err := Load(t.TempDir())
 	if err != nil {
@@ -163,6 +226,15 @@ func TestLoadIgnoresMissingUserConfig(t *testing.T) {
 	if cost.USD <= 0 {
 		t.Fatalf("default catalog did not price known model: %+v", cost)
 	}
+}
+
+func containsAll(value string, needles ...string) bool {
+	for _, needle := range needles {
+		if !strings.Contains(value, needle) {
+			return false
+		}
+	}
+	return true
 }
 
 func TestDefaultCatalogCoversCodexAutoReview(t *testing.T) {


### PR DESCRIPTION
## Summary

- Add `aitok pricing configure` for local offline pricing overrides with numbered terminal Q/A prompts.
- Add scriptable pricing configuration flags and JSON output that keeps prompts off stdout.
- Add project-local `make run ARGS="..."` for CLI smoke commands so Go cache stays under `.cache/aitok`.
- Document provider/auth-label pricing, raw API key guardrails, and the follow-up iteration note in English and zh-CN.

## Requirement Classification

- Type: feature
- User-visible outcome: users can configure different local pricing for provider/auth labels from the terminal without manually editing JSON.
- Target platform(s): CLI on local developer machines and automation using `--format json --no-version-check`.
- Scope assumptions: raw API keys remain out of scope; matching uses model substring plus provider/auth labels already present in local tool logs.

## Acceptance Criteria

- [x] Criteria are written before implementation starts.
- [x] Each criterion maps to unit test coverage where practical.
- [x] Each criterion maps to CLI/manual/platform evidence where relevant.
- [x] At least one failure or edge case is covered, or a reason is documented.

Criteria:

- `pricing configure` writes or updates `~/.aitok/pricing.json` with provider-specific price overrides.
- Interactive mode uses numbered Q/A prompts and rejects raw API-key-like provider input.
- JSON mode keeps stdout machine-readable and writes prompts to stderr when interaction is needed.
- Local CLI smoke commands can use project-local Go cache through `make run ARGS="..."`.
- Existing pricing load behavior keeps merging user overrides over bundled defaults.

## Changed Areas

- `internal/cli`: pricing configure command, Q/A prompt flow, JSON-safe prompt routing.
- `internal/pricing`: user config load/save/upsert helpers and validation.
- `Makefile`: project-local `make run` CLI wrapper.
- `README*`, `AGENTS*`, iteration notes: usage, cache, release, and API-key guardrail documentation.

## Release Decision

- Release required after merge: this is a user-visible CLI feature.

## TDD / Test Evidence

- Test/sensor added before implementation: targeted CLI and pricing unit coverage was added with the implementation.
- Unit tests:
  - `TestPricingConfigureCommandWritesInteractiveOverride`
  - `TestPricingConfigureCommandSupportsFlagOnlyJSON`
  - `TestPricingConfigureJSONKeepsPromptsOffStdout`
  - `TestPricingConfigureRejectsRawAPIKeyProvider`
  - `TestSaveUserPriceUpsertsProviderSpecificOverride`
  - `TestSaveUserPriceRejectsRawAPIKeyProvider`
- CLI/manual/platform evidence:
  - `make run ARGS='--home /private/tmp/aitok-pricing-smoke --no-version-check pricing configure --model gpt-5.4 --provider team-make-run --input-usd-per-mtok 4 --output-usd-per-mtok 40 --cache-hit-usd-per-mtok 0.4 --cache-make-usd-per-mtok 4 --cache-make-1h-usd-per-mtok 0 --multiplier 1 --format json'`
  - Q/A smoke via piped answers into `make run ARGS='--home /private/tmp/aitok-pricing-qa-smoke --no-version-check pricing configure'`
  - Local verification of `toska` provider pricing with existing `~/.aitok/pricing.json`: summary cost matched manual calculation and `pricing audit` returned no unpriced rows for today.
- Failure and edge cases covered: raw API-key-like provider labels are rejected; JSON interactive prompts stay off stdout; same model can have separate provider-specific overrides.
- Acceptance criteria evidence map: covered by the tests and CLI smoke commands listed above.

## Validation

- [x] `make check`
- [x] `make test`
- [x] `make test-harness`
- [x] `make build`
- [x] Commit message follows `go run ./tools/commitlint --edit <commit-msg-file>`
- Skipped validation and reason: none.

## Risk and Rollback

- Risk: provider-specific matching still depends on provider/auth labels being present in local logs; tools that do not expose distinct labels cannot safely distinguish raw API keys.
- Rollback: revert commit `9236333` to remove the new configure command and docs while preserving existing manual JSON override behavior.
- Residual risk: future UX polish may be needed for richer editing/listing of existing pricing overrides, but current behavior is compatible with existing `~/.aitok/pricing.json`.
