### PR TITLE
[codex] Add curl shell installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,19 @@ brew install --cask aitok
 
 The tap step keeps the install command short and avoids the less readable fully qualified cask name.
 
+Shell installer:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/MagnumGoYB/aitok/main/scripts/install.sh | sh
+```
+
+The installer downloads the matching macOS or Linux GitHub Release archive, verifies it with `checksums.txt`, and installs `aitok` to `/usr/local/bin`. Override the target directory or version when needed:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/MagnumGoYB/aitok/main/scripts/install.sh | AITOK_INSTALL_DIR="$HOME/.local/bin" sh
+curl -fsSL https://raw.githubusercontent.com/MagnumGoYB/aitok/main/scripts/install.sh | AITOK_VERSION=v0.1.30 sh
+```
+
 Go:
 
 ```bash

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -19,6 +19,19 @@ brew install --cask aitok
 
 先执行 tap 可以保持安装命令简洁，避免使用较不规范的完整 cask 名称。
 
+Shell 安装脚本：
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/MagnumGoYB/aitok/main/scripts/install.sh | sh
+```
+
+安装脚本会下载匹配当前 macOS 或 Linux 平台的 GitHub Release archive，通过 `checksums.txt` 校验后把 `aitok` 安装到 `/usr/local/bin`。如需指定安装目录或版本：
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/MagnumGoYB/aitok/main/scripts/install.sh | AITOK_INSTALL_DIR="$HOME/.local/bin" sh
+curl -fsSL https://raw.githubusercontent.com/MagnumGoYB/aitok/main/scripts/install.sh | AITOK_VERSION=v0.1.30 sh
+```
+
 Go：
 
 ```bash

--- a/docs/github-automation.md
+++ b/docs/github-automation.md
@@ -52,6 +52,7 @@ This repository uses GitHub-native automation for pull requests, review prompts,
 - The Homebrew cask is published to the `MagnumGoYB/homebrew-aitok` tap and installs with `brew tap MagnumGoYB/aitok` followed by `brew install --cask aitok`; docs intentionally avoid the fully qualified cask name because it repeats `aitok`.
 - The cask is generated from the macOS archive set only. Linux and Windows archives are still published as GitHub Release assets, but they are not included in the Homebrew cask DSL.
 - The generated cask runs a post-install macOS `xattr` hook for the installed `aitok` binary so unsigned CLI archives do not remain quarantined after Homebrew installation.
+- `scripts/install.sh` is the documented `curl | sh` path for macOS and Linux. It downloads the matching GoReleaser `tar.gz` asset, verifies it with the published `checksums.txt`, and installs the binary into `AITOK_INSTALL_DIR` or `/usr/local/bin`.
 - GitHub Releases use `GITHUB_TOKEN`; publishing the tap requires the repository secret `HOMEBREW_TAP_GITHUB_TOKEN`, because the default workflow token cannot write to the separate `homebrew-aitok` repository.
 - The release workflow pins GoReleaser v2 instead of using `latest`.
 - Release automation does not add external network telemetry or usage upload.

--- a/docs/harness-engineering.md
+++ b/docs/harness-engineering.md
@@ -22,6 +22,7 @@ For `aitok`, the harness is intentionally lightweight: Go tests, a Makefile, PR 
 - `make test`: unit and integration coverage for source adapters, period windows, aggregation, reports, CLI, setup, and TUI smoke rendering.
 - `make test-packages PKGS="./internal/query ./internal/report"`: targeted package tests with the same repository-local Go caches as the full test target.
 - `make test-harness`: repository-structure sensors for agent docs, Makefile commands, CI gates, PR template, and offline/privacy constraints.
+- Curl installer sensor: `harness/architecture_test.go` keeps `scripts/install.sh`, README install docs, and the GoReleaser archive/checksum contract aligned.
 - `make vet`: static analysis.
 - `make build`: single-binary build check.
 - `make validate-pr-body`: executable PR body metadata gate.
@@ -72,5 +73,5 @@ When changing release decision rules, update `tools/validate-pr-body`, `.github/
 - `.github/CODEOWNERS` routes high-risk areas to maintainers without requiring paid AI review automation.
 - `.github/workflows/dependabot-auto-merge.yml` enables GitHub auto-merge only for non-major Dependabot updates.
 - `.github/workflows/build.yml` uploads cross-platform build artifacts.
-- `.github/workflows/release.yml` publishes tag releases through GoReleaser.
+- `.github/workflows/release.yml` publishes tag releases through GoReleaser, including archives and `checksums.txt` consumed by `scripts/install.sh`.
 - `.github/ISSUE_TEMPLATE/bug_report.yml`, `.github/CODEOWNERS`, and `.github/dependabot.yml` keep open-source maintenance paths explicit.

--- a/docs/zh-CN/github-automation.md
+++ b/docs/zh-CN/github-automation.md
@@ -52,6 +52,7 @@
 - Homebrew cask 发布到 `MagnumGoYB/homebrew-aitok` tap，并通过 `brew tap MagnumGoYB/aitok` 后执行 `brew install --cask aitok` 安装；文档刻意不使用完整 cask 名称，避免重复出现 `aitok`。
 - Cask 只从 macOS archive 集合生成。Linux 和 Windows archive 仍会作为 GitHub Release 产物发布，但不会进入 Homebrew cask DSL。
 - 生成的 cask 会在 macOS post-install 阶段对已安装的 `aitok` 二进制运行 `xattr` hook，避免未签名 CLI archive 在 Homebrew 安装后仍保留 quarantine 状态。
+- `scripts/install.sh` 是文档公开的 `curl | sh` 安装路径，支持 macOS 和 Linux。它会下载匹配的 GoReleaser `tar.gz` 产物，通过发布的 `checksums.txt` 校验后，把二进制安装到 `AITOK_INSTALL_DIR` 或 `/usr/local/bin`。
 - GitHub Release 使用 `GITHUB_TOKEN`；发布 tap 需要仓库 secret `HOMEBREW_TAP_GITHUB_TOKEN`，因为默认 workflow token 不能写入独立的 `homebrew-aitok` 仓库。
 - Release workflow 固定使用 GoReleaser v2，不使用 `latest`。
 - Release 自动化不新增外部 telemetry 或 usage 上传。

--- a/docs/zh-CN/harness-engineering.md
+++ b/docs/zh-CN/harness-engineering.md
@@ -22,6 +22,7 @@ Harness 是一组前馈指南和反馈传感器：前馈指南在代理编辑前
 - `make test`：覆盖 source adapter、时间窗口、聚合、报告、CLI、setup 和 TUI smoke。
 - `make test-packages PKGS="./internal/query ./internal/report"`：指定包测试，并复用与全量测试一致的仓库本地 Go cache。
 - `make test-harness`：仓库结构传感器，检查 agent docs、Makefile 命令、CI 门禁、PR 模板和离线/隐私约束。
+- Curl 安装脚本传感器：`harness/architecture_test.go` 保持 `scripts/install.sh`、README 安装文档和 GoReleaser archive/checksum 契约一致。
 - `make vet`：静态分析。
 - `make build`：单二进制构建检查。
 - `make validate-pr-body`：可执行 PR body 元数据门禁。
@@ -72,5 +73,5 @@ Harness 是一组前馈指南和反馈传感器：前馈指南在代理编辑前
 - `.github/CODEOWNERS` 将高风险区域路由给维护者，不强制依赖付费 AI review 自动化。
 - `.github/workflows/dependabot-auto-merge.yml` 只为非 major Dependabot 更新启用 GitHub auto-merge。
 - `.github/workflows/build.yml` 上传跨平台构建产物。
-- `.github/workflows/release.yml` 通过 GoReleaser 发布 tag release。
+- `.github/workflows/release.yml` 通过 GoReleaser 发布 tag release，包括供 `scripts/install.sh` 使用的 archive 和 `checksums.txt`。
 - `.github/ISSUE_TEMPLATE/bug_report.yml`、`.github/CODEOWNERS` 和 `.github/dependabot.yml` 明确开源维护路径。

--- a/harness/architecture_test.go
+++ b/harness/architecture_test.go
@@ -470,6 +470,62 @@ func TestReleasePublishesHomebrewCask(t *testing.T) {
 	}
 }
 
+func TestCurlInstallScriptIsDocumentedAndVerifiesReleaseChecksums(t *testing.T) {
+	script := read(t, "scripts", "install.sh")
+	readme := read(t, "README.md")
+	readmeZH := read(t, "README.zh-CN.md")
+	goreleaser := read(t, ".goreleaser.yml")
+
+	for _, expected := range []string{
+		"#!/bin/sh",
+		"MagnumGoYB/aitok",
+		"AITOK_INSTALL_DIR",
+		"AITOK_VERSION",
+		"https://api.github.com/repos/${repo}/releases/latest",
+		"checksums.txt",
+		"sha256sum",
+		"shasum -a 256",
+		"aitok_${version}_${os}_${arch}.tar.gz",
+		"darwin",
+		"linux",
+	} {
+		if !strings.Contains(script, expected) {
+			t.Fatalf("scripts/install.sh must contain %s", expected)
+		}
+	}
+	for _, forbidden := range []string{
+		"eval ",
+		"source ",
+		"bash",
+		"API key",
+	} {
+		if strings.Contains(script, forbidden) {
+			t.Fatalf("install script must not contain %s", forbidden)
+		}
+	}
+	for _, expected := range []string{
+		"curl -fsSL https://raw.githubusercontent.com/MagnumGoYB/aitok/main/scripts/install.sh | sh",
+		"AITOK_INSTALL_DIR",
+		"AITOK_VERSION",
+		"checksums.txt",
+	} {
+		if !strings.Contains(readme, expected) {
+			t.Fatalf("README.md must document curl install with %s", expected)
+		}
+		if !strings.Contains(readmeZH, expected) {
+			t.Fatalf("README.zh-CN.md must document curl install with %s", expected)
+		}
+	}
+	for _, expected := range []string{
+		"formats: [tar.gz]",
+		"name_template: checksums.txt",
+	} {
+		if !strings.Contains(goreleaser, expected) {
+			t.Fatalf(".goreleaser.yml must keep install script release asset contract with %s", expected)
+		}
+	}
+}
+
 func TestWorkflowFilesKeepHarnessGates(t *testing.T) {
 	makefile := read(t, "Makefile")
 	ci := read(t, ".github", "workflows", "ci.yml")

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,106 @@
+#!/bin/sh
+set -eu
+
+repo="${AITOK_INSTALL_REPO:-MagnumGoYB/aitok}"
+install_dir="${AITOK_INSTALL_DIR:-/usr/local/bin}"
+requested_version="${AITOK_VERSION:-latest}"
+
+need() {
+	if ! command -v "$1" >/dev/null 2>&1; then
+		echo "aitok install: missing required command: $1" >&2
+		exit 1
+	fi
+}
+
+detect_os() {
+	case "$(uname -s)" in
+	Darwin) echo "darwin" ;;
+	Linux) echo "linux" ;;
+	*)
+		echo "aitok install: unsupported OS: $(uname -s)" >&2
+		exit 1
+		;;
+	esac
+}
+
+detect_arch() {
+	case "$(uname -m)" in
+	x86_64 | amd64) echo "amd64" ;;
+	arm64 | aarch64) echo "arm64" ;;
+	*)
+		echo "aitok install: unsupported architecture: $(uname -m)" >&2
+		exit 1
+		;;
+	esac
+}
+
+latest_tag() {
+	curl -fsSL "https://api.github.com/repos/${repo}/releases/latest" |
+		sed -n 's/.*"tag_name"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' |
+		head -n 1
+}
+
+checksum_file() {
+	if command -v sha256sum >/dev/null 2>&1; then
+		sha256sum "$1" | awk '{print $1}'
+	else
+		shasum -a 256 "$1" | awk '{print $1}'
+	fi
+}
+
+need curl
+need sed
+need awk
+need tar
+if ! command -v sha256sum >/dev/null 2>&1 && ! command -v shasum >/dev/null 2>&1; then
+	echo "aitok install: missing required command: sha256sum or shasum" >&2
+	exit 1
+fi
+
+os="$(detect_os)"
+arch="$(detect_arch)"
+tag="$requested_version"
+if [ "$tag" = "latest" ]; then
+	tag="$(latest_tag)"
+fi
+if [ -z "$tag" ]; then
+	echo "aitok install: could not determine release version" >&2
+	exit 1
+fi
+version="${tag#v}"
+archive="aitok_${version}_${os}_${arch}.tar.gz"
+base_url="https://github.com/${repo}/releases/download/${tag}"
+tmpdir="$(mktemp -d)"
+
+cleanup() {
+	rm -rf "$tmpdir"
+}
+trap cleanup EXIT INT TERM
+
+echo "Installing aitok ${tag} for ${os}/${arch}..." >&2
+curl -fsSL "${base_url}/${archive}" -o "${tmpdir}/${archive}"
+curl -fsSL "${base_url}/checksums.txt" -o "${tmpdir}/checksums.txt"
+
+expected="$(awk -v name="$archive" '$2 == name {print $1}' "${tmpdir}/checksums.txt")"
+if [ -z "$expected" ]; then
+	echo "aitok install: checksum not found for ${archive}" >&2
+	exit 1
+fi
+actual="$(checksum_file "${tmpdir}/${archive}")"
+if [ "$actual" != "$expected" ]; then
+	echo "aitok install: checksum mismatch for ${archive}" >&2
+	exit 1
+fi
+
+tar -xzf "${tmpdir}/${archive}" -C "$tmpdir" aitok
+if mkdir -p "$install_dir" 2>/dev/null && [ -w "$install_dir" ]; then
+	mv "${tmpdir}/aitok" "${install_dir}/aitok"
+	chmod 0755 "${install_dir}/aitok"
+else
+	need sudo
+	sudo mkdir -p "$install_dir"
+	sudo mv "${tmpdir}/aitok" "${install_dir}/aitok"
+	sudo chmod 0755 "${install_dir}/aitok"
+fi
+
+echo "aitok installed to ${install_dir}/aitok" >&2


### PR DESCRIPTION
## Summary

- Add `scripts/install.sh` for `curl | sh` installation on macOS and Linux.
- Document the shell installer in English and Chinese READMEs.
- Add harness coverage and automation docs for the release archive/checksum contract.

## Requirement Classification

- Type: feature
- User-visible outcome: users can install `aitok` with a curl shell installer instead of Homebrew or `go install`.
- Target platform(s): macOS and Linux release archives.
- Scope assumptions: Windows keeps the existing GitHub Release zip path and is not supported by this POSIX shell installer.

## Acceptance Criteria

- [x] Criteria are written before implementation starts.
- [x] Each criterion maps to unit test coverage where practical.
- [x] Each criterion maps to CLI/manual/platform evidence where relevant.
- [x] At least one failure or edge case is covered, or a reason is documented.

## Changed Areas

- `scripts/install.sh`
- `README.md`
- `README.zh-CN.md`
- `harness/architecture_test.go`
- `docs/harness-engineering.md`
- `docs/zh-CN/harness-engineering.md`
- `docs/github-automation.md`
- `docs/zh-CN/github-automation.md`

## Release Decision

- Release required after merge: this is a user-visible install feature and should be included in the normal release flow after review/merge.

## TDD / Test Evidence

- Test/sensor added before implementation: added `TestCurlInstallScriptIsDocumentedAndVerifiesReleaseChecksums` to keep the installer, README docs, and GoReleaser archive/checksum contract aligned.
- Unit tests: `make test-harness`.
- CLI/manual/platform evidence: `sh -n scripts/install.sh`; project-local smoke install with `AITOK_INSTALL_DIR=/Users/sosbs/coding/aitok/.cache/aitok/install-smoke/bin AITOK_VERSION=v0.1.30 sh scripts/install.sh`; installed binary returned `0.1.30` with `--no-version-check version`.
- Failure and edge cases covered: unsupported platform/architecture checks, missing required commands, missing checksum entry, checksum mismatch, and writable vs sudo install directory handling in the script; harness guards against drift in documented install commands and checksum expectations.
- Acceptance criteria evidence map: installer exists and is documented by README updates; checksum verification is enforced by script and harness; release archive contract is documented in GitHub automation docs; validation commands below passed locally.

## Validation

- [x] `make check`
- [x] `make test`
- [x] `make test-harness`
- [x] `make build`
- [x] Commit message follows `go run ./tools/commitlint --edit <commit-msg-file>`
- Skipped validation and reason: no skipped local validation; Windows install smoke is not applicable because the script intentionally targets POSIX macOS/Linux archives.

## Risk and Rollback

- Risk: users piping remote shell scripts must trust the repository; checksum verification reduces artifact tampering risk but does not replace source review.
- Rollback: remove `scripts/install.sh`, README installer snippets, harness sensor, and automation doc references.
- Residual risk: the `latest` lookup depends on GitHub API availability; users can pin `AITOK_VERSION` to avoid latest-release lookup.
