### PR TITLE
perf: reduce multi-tool summary overhead

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -14,14 +14,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
       - uses: actions/setup-go@v6
         with:
           go-version: "1.26.3"
           cache: true
       - run: make validate-pr-body
-      - name: Fetch pull request commits
-        run: git fetch --no-tags --depth=1 origin "${{ github.event.pull_request.head.sha }}"
-      - name: Validate latest commit message
-        run: |
-          git log -1 --format=%B "${{ github.event.pull_request.head.sha }}" > /tmp/aitok-pr-commit-msg
-          make commitlint COMMIT_MSG_FILE=/tmp/aitok-pr-commit-msg
+      - name: Validate pull request commit messages
+        run: make commitlint-range COMMIT_RANGE="${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }}"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -118,7 +118,7 @@ Before every product or harness iteration, do a short internal review:
 - CI must run `make validate` and `make test-harness`.
 - PRs must include Summary, Requirement Classification, Acceptance Criteria, Changed Areas, Release Decision, TDD / Test Evidence, Validation, and Risk and Rollback.
 - Feature and bugfix PRs must mark release required after merge or identify the explicit user-approved deferral. Harness/tooling, docs, CI, and other engineering-process-only PRs should mark release not required.
-- Commit messages must match the repository Go commitlint format: `{emoji} {type}{scope}: {subject}`. Run `make setup` once to enable `.githooks/commit-msg`, or run `make commitlint COMMIT_MSG_FILE=<commit-msg-file>` directly. PR CI also validates the latest PR commit message.
+- Commit messages must match the repository Go commitlint format: `{emoji} {type}{scope}: {subject}`, and the emoji must match the commit type. Current mapping: `✨ feat`, `🐛 fix`, `📝 docs`, `👷 ci`, `💄 style`, `♻️ refactor`, `🔖 release`, `⚡️ perf`, `✅ test`, `🔧 chore`, `🏗️ build`. Run `make setup` once to enable `.githooks/commit-msg`, or run `make commitlint COMMIT_MSG_FILE=<commit-msg-file>` directly. PR CI validates every commit message in the PR range.
 - Do not claim completion after skipping local validation.
 - Stage/commit only files that belong to the current iteration; do not include unrelated dirty files.
 

--- a/AGENTS.zh-CN.md
+++ b/AGENTS.zh-CN.md
@@ -118,7 +118,7 @@
 - CI 必须运行 `make validate`、`make test-harness`。
 - PR 必须包含 Summary、Requirement Classification、Acceptance Criteria、Changed Areas、Release Decision、TDD / Test Evidence、Validation、Risk and Rollback。
 - feature 和 bugfix PR 必须标记合并后需要发版，或写明用户已明确批准延后。Harness/tooling、docs、CI 和其他工程流程优化 PR 应标记无需发版。
-- 提交消息必须符合仓库内 Go commitlint 格式：`{emoji} {type}{scope}: {subject}`。先运行一次 `make setup` 启用 `.githooks/commit-msg`，或直接运行 `make commitlint COMMIT_MSG_FILE=<commit-msg-file>`。PR CI 也会校验 PR 最新提交消息。
+- 提交消息必须符合仓库内 Go commitlint 格式：`{emoji} {type}{scope}: {subject}`，并且 emoji 必须匹配提交 type。当前映射：`✨ feat`、`🐛 fix`、`📝 docs`、`👷 ci`、`💄 style`、`♻️ refactor`、`🔖 release`、`⚡️ perf`、`✅ test`、`🔧 chore`、`🏗️ build`。先运行一次 `make setup` 启用 `.githooks/commit-msg`，或直接运行 `make commitlint COMMIT_MSG_FILE=<commit-msg-file>`。PR CI 会校验 PR range 内的每个提交消息。
 - 不要绕过本地验证后声称完成。
 - Stage/commit 只包含当前迭代文件；不要纳入无关 dirty files。
 

--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,9 @@ AITOK_CACHE_DIR ?= $(CURDIR)/.cache/aitok
 GOCACHE ?= $(AITOK_CACHE_DIR)/go-build
 GOMODCACHE ?= $(AITOK_CACHE_DIR)/go-mod
 COMMIT_MSG_FILE ?= .git/COMMIT_EDITMSG
+COMMIT_RANGE ?=
 
-.PHONY: setup check test test-packages test-harness vet build run validate validate-pr-body commitlint
+.PHONY: setup check test test-packages test-harness vet build run validate validate-pr-body commitlint commitlint-range
 
 setup:
 	git config core.hooksPath .githooks
@@ -37,5 +38,9 @@ validate-pr-body:
 
 commitlint:
 	GOCACHE=$(GOCACHE) GOMODCACHE=$(GOMODCACHE) $(GO) run ./tools/commitlint --edit "$(COMMIT_MSG_FILE)"
+
+commitlint-range:
+	@test -n "$(COMMIT_RANGE)" || (echo 'COMMIT_RANGE is required, for example: make commitlint-range COMMIT_RANGE="origin/main..HEAD"' >&2; exit 2)
+	GOCACHE=$(GOCACHE) GOMODCACHE=$(GOMODCACHE) $(GO) run ./tools/commitlint --range "$(COMMIT_RANGE)"
 
 validate: check test build

--- a/docs/harness-engineering.md
+++ b/docs/harness-engineering.md
@@ -12,7 +12,7 @@ For `aitok`, the harness is intentionally lightweight: Go tests, a Makefile, PR 
 - `README.md`: user-facing CLI usage and install path.
 - `CONTRIBUTING.md`: contributor validation and offline-first rules.
 - `Makefile`: canonical local commands: `make setup`, `make check`, `make test`, `make test-packages`, `make test-harness`, `make vet`, `make build`, `make validate`, `make validate-pr-body`, and `make commitlint`.
-- `tools/commitlint` and `.githooks/commit-msg`: repository-native Go commit-message validation for `{emoji} {type}{scope}: {subject}` without Node/npm tooling. `make setup` enables the hook for local commits.
+- `tools/commitlint` and `.githooks/commit-msg`: repository-native Go commit-message validation for `{emoji} {type}{scope}: {subject}` without Node/npm tooling. Each commit type has exactly one allowed emoji: `✨ feat`, `🐛 fix`, `📝 docs`, `👷 ci`, `💄 style`, `♻️ refactor`, `🔖 release`, `⚡️ perf`, `✅ test`, `🔧 chore`, and `🏗️ build`. `make setup` enables the hook for local commits.
 - `.github/pull_request_template.md`: repeatable PR checklist for requirement classification, acceptance criteria, test evidence, validation, rollback, and residual risk.
 - Release decision policy: engineering/process-only changes do not require a software release; feature and bugfix changes require a follow-up release or explicit deferral.
 - `.github/workflows/ci.yml`: hosted validation matching the local gates.
@@ -27,7 +27,8 @@ For `aitok`, the harness is intentionally lightweight: Go tests, a Makefile, PR 
 - `make build`: single-binary build check.
 - `make validate-pr-body`: executable PR body metadata gate.
 - `make setup`: one-time local setup that runs `git config core.hooksPath .githooks`.
-- `make commitlint COMMIT_MSG_FILE=<commit-msg-file>`: executable commit-message gate, wired through `.githooks/commit-msg` after setup and mirrored by PR CI for the latest PR commit.
+- `make commitlint COMMIT_MSG_FILE=<commit-msg-file>`: executable single commit-message gate, wired through `.githooks/commit-msg` after setup.
+- `make commitlint-range COMMIT_RANGE=<base..head>`: executable PR-range commit-message gate, mirrored by PR CI for every commit in the PR.
 - `.cache/aitok/`: repository-local, git-ignored Go build/module cache used by Makefile targets so agent verification stays bound to this checkout instead of ad hoc `/tmp` paths.
 - Agents should not run raw `go test`, `go vet`, `go build`, or `go run` in sandboxed sessions. Use Makefile targets so Go never falls back to `~/Library/Caches/go-build`.
 

--- a/docs/iteration-notes/2026-05-09-agent-cost-governance.md
+++ b/docs/iteration-notes/2026-05-09-agent-cost-governance.md
@@ -199,7 +199,8 @@ Commitlint:
 
 - `make setup` now runs `git config core.hooksPath .githooks`.
 - `.githooks/commit-msg` runs `make commitlint COMMIT_MSG_FILE="$1"`.
-- `.github/workflows/pr.yml` fetches the PR head SHA and validates the latest commit message with `make commitlint`, so local setup is helpful but not the only gate.
+- `.github/workflows/pr.yml` validates every commit in the PR range with `make commitlint-range COMMIT_RANGE="<base>..<head>"`, so local setup is helpful but not the only gate.
+- Commit emoji is type-specific and has exactly one allowed value per type: `✨ feat`, `🐛 fix`, `📝 docs`, `👷 ci`, `💄 style`, `♻️ refactor`, `🔖 release`, `⚡️ perf`, `✅ test`, `🔧 chore`, and `🏗️ build`.
 
 Release decision:
 

--- a/docs/zh-CN/harness-engineering.md
+++ b/docs/zh-CN/harness-engineering.md
@@ -12,7 +12,7 @@ Harness 是一组前馈指南和反馈传感器：前馈指南在代理编辑前
 - `README.md`：面向用户的 CLI 使用和安装路径。
 - `CONTRIBUTING.md`：贡献者验证和离线优先规则。
 - `Makefile`：标准本地命令：`make setup`、`make check`、`make test`、`make test-packages`、`make test-harness`、`make vet`、`make build`、`make validate`、`make validate-pr-body` 和 `make commitlint`。
-- `tools/commitlint` 和 `.githooks/commit-msg`：仓库内 Go 提交消息校验，约束 `{emoji} {type}{scope}: {subject}`，不引入 Node/npm 工具链。`make setup` 会为本地提交启用该 hook。
+- `tools/commitlint` 和 `.githooks/commit-msg`：仓库内 Go 提交消息校验，约束 `{emoji} {type}{scope}: {subject}`，不引入 Node/npm 工具链。每个提交 type 只允许一个 emoji：`✨ feat`、`🐛 fix`、`📝 docs`、`👷 ci`、`💄 style`、`♻️ refactor`、`🔖 release`、`⚡️ perf`、`✅ test`、`🔧 chore`、`🏗️ build`。`make setup` 会为本地提交启用该 hook。
 - `.github/pull_request_template.md`：可重复的 PR 检查清单，覆盖需求分类、验收标准、测试证据、验证、回滚和残余风险。
 - 发版判定策略：工程/流程优化不需要软件发版；feature 和 bugfix 需要跟进发版或明确延后。
 - `.github/workflows/ci.yml`：与本地门禁一致的托管验证。
@@ -27,7 +27,8 @@ Harness 是一组前馈指南和反馈传感器：前馈指南在代理编辑前
 - `make build`：单二进制构建检查。
 - `make validate-pr-body`：可执行 PR body 元数据门禁。
 - `make setup`：一次性本地设置，执行 `git config core.hooksPath .githooks`。
-- `make commitlint COMMIT_MSG_FILE=<commit-msg-file>`：可执行提交消息门禁，setup 后通过 `.githooks/commit-msg` 接入，并由 PR CI 校验 PR 最新提交。
+- `make commitlint COMMIT_MSG_FILE=<commit-msg-file>`：可执行单条提交消息门禁，setup 后通过 `.githooks/commit-msg` 接入。
+- `make commitlint-range COMMIT_RANGE=<base..head>`：可执行 PR range 提交消息门禁，由 PR CI 校验 PR 内每个提交。
 - `.cache/aitok/`：仓库内、git 忽略的 Go build/module cache，供 Makefile 目标使用，让 agent 校验绑定当前 checkout，而不是临时拼接 `/tmp` 路径。
 - Agent 在沙箱 session 内不要直接运行 raw `go test`、`go vet`、`go build` 或 `go run`。统一使用 Makefile 目标，避免 Go 回退到 `~/Library/Caches/go-build`。
 

--- a/docs/zh-CN/iteration-notes/2026-05-09-agent-cost-governance.md
+++ b/docs/zh-CN/iteration-notes/2026-05-09-agent-cost-governance.md
@@ -34,7 +34,7 @@
 7. 发布 `v0.1.15`，GoReleaser 产出 darwin、linux、windows 包。
 8. 增加这份仓库级交接记录，避免后续会话依赖 Codex 全局 memory 索引。
 9. 移除常驻 CodeRabbit review，因为持续付费的 PR review 门禁对本仓库不划算。
-10. 增加 `make setup` 和 PR 侧最新提交 commitlint，让人工提交和 Agent 提交共用同一套提交消息契约。
+10. 增加 `make setup` 和 PR range commitlint，让人工提交和 Agent 提交共用同一套提交消息契约。
 11. 增加显式 PR 发版判定门禁：工程/流程优化不触发软件发版，feature 和 bugfix 必须标记后续发版或明确延后。
 
 ## 产品决策
@@ -149,7 +149,7 @@
 - checkout 内 CLI smoke 使用 `make run ARGS="..."`，不要直接裸跑 `go run`
 - 每个 checkout 运行一次 `make setup`，启用 `.githooks/commit-msg`
 - 提交信息校验使用 `make commitlint COMMIT_MSG_FILE=<commit-msg-file>`
-- PR CI 校验 PR 最新提交消息，所以没有运行本地 setup 的贡献者也会被覆盖
+- PR CI 校验 PR range 内每个提交消息，所以没有运行本地 setup 的贡献者也会被覆盖
 
 类似 `/tmp/aitok-commit-msg` 的文件不是项目工具，只是一次性命令输入。
 
@@ -199,7 +199,8 @@ Commitlint：
 
 - `make setup` 会执行 `git config core.hooksPath .githooks`。
 - `.githooks/commit-msg` 执行 `make commitlint COMMIT_MSG_FILE="$1"`。
-- `.github/workflows/pr.yml` 会 fetch PR head SHA，并用 `make commitlint` 校验 PR 最新提交消息；本地 setup 有帮助，但不是唯一门禁。
+- `.github/workflows/pr.yml` 会用 `make commitlint-range COMMIT_RANGE="<base>..<head>"` 校验 PR range 内每个提交消息；本地 setup 有帮助，但不是唯一门禁。
+- 提交 emoji 与 type 强绑定，且每个 type 只允许一个值：`✨ feat`、`🐛 fix`、`📝 docs`、`👷 ci`、`💄 style`、`♻️ refactor`、`🔖 release`、`⚡️ perf`、`✅ test`、`🔧 chore`、`🏗️ build`。
 
 发版判定：
 

--- a/harness/architecture_test.go
+++ b/harness/architecture_test.go
@@ -63,13 +63,13 @@ func TestCommitWorkflowSupportsHumanAndHostedValidation(t *testing.T) {
 
 	prWorkflow := read(t, ".github", "workflows", "pr.yml")
 	for _, expected := range []string{
-		"Fetch pull request commits",
+		"fetch-depth: 0",
+		"github.event.pull_request.base.sha",
 		"github.event.pull_request.head.sha",
-		"git log -1 --format=%B",
-		"make commitlint COMMIT_MSG_FILE=",
+		"make commitlint-range COMMIT_RANGE=",
 	} {
 		if !strings.Contains(prWorkflow, expected) {
-			t.Fatalf("PR workflow must validate the latest commit message with %s", expected)
+			t.Fatalf("PR workflow must validate every PR commit message with %s", expected)
 		}
 	}
 }
@@ -534,7 +534,7 @@ func TestWorkflowFilesKeepHarnessGates(t *testing.T) {
 	prTemplate := read(t, ".github", "pull_request_template.md")
 	gitignore := read(t, ".gitignore")
 
-	for _, target := range []string{"check:", "test:", "test-packages:", "test-harness:", "build:", "validate-pr-body:", "commitlint:", "validate:"} {
+	for _, target := range []string{"check:", "test:", "test-packages:", "test-harness:", "build:", "validate-pr-body:", "commitlint:", "commitlint-range:", "validate:"} {
 		if !strings.Contains(makefile, target) {
 			t.Fatalf("Makefile missing %s", target)
 		}
@@ -617,9 +617,13 @@ func TestCommitWorkflowConfigurationStaysExecutable(t *testing.T) {
 	commitlint := read(t, "tools", "commitlint", "main.go")
 	for _, expected := range []string{
 		`maxHeaderLength = 64`,
-		`emoji + " " + type + optional scope + ": " + subject`,
+		`type-specific emoji + " " + type + optional scope + ": " + subject`,
+		`typeEmojiValues`,
+		`lintCommitRange`,
 		`"feat"`,
 		`"fix"`,
+		`"perf"`,
+		`"test"`,
 		`"harness"`,
 		`"sources"`,
 	} {
@@ -644,6 +648,13 @@ func TestCommitWorkflowConfigurationStaysExecutable(t *testing.T) {
 	for _, expected := range []string{"make commitlint COMMIT_MSG_FILE=", ".githooks/commit-msg", "{emoji} {type}{scope}: {subject}"} {
 		if !strings.Contains(docs, expected) {
 			t.Fatalf("agent and PR docs must mention %s", expected)
+		}
+	}
+
+	workflow := read(t, ".github", "workflows", "pr.yml")
+	for _, expected := range []string{"make commitlint-range COMMIT_RANGE=", "pull request commit messages"} {
+		if !strings.Contains(workflow, expected) {
+			t.Fatalf("PR workflow must validate all PR commit messages with %s", expected)
 		}
 	}
 }

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -170,6 +170,47 @@ func TestSummaryUsesCustomPricingFile(t *testing.T) {
 	}
 }
 
+func TestSummaryPerModelPricingStaysAccurate(t *testing.T) {
+	home := t.TempDir()
+	pricingPath := filepath.Join(home, "pricing.json")
+	writeFixture(t, pricingPath, `{"models":[{"match":"gpt-5.4","input_usd_per_mtok":2},{"match":"claude-sonnet-4","input_usd_per_mtok":3},{"match":"gemini-2.5-flash","input_usd_per_mtok":0.3}]}`)
+	writeFixture(t, filepath.Join(home, ".codex", "sessions", "2026", "05", "08", "gpt.jsonl"),
+		`{"type":"session_meta","timestamp":"2026-05-08T01:00:00Z","payload":{"model_provider":"openai","cwd":"/repo"}}`+"\n"+
+			`{"type":"turn_context","timestamp":"2026-05-08T01:00:01Z","payload":{"model":"gpt-5.4","cwd":"/repo"}}`+"\n"+
+			`{"type":"event_msg","timestamp":"2026-05-08T01:00:02Z","payload":{"type":"token_count","info":{"last_token_usage":{"input_tokens":1000000,"total_tokens":1000000}}}}`+"\n")
+	writeFixture(t, filepath.Join(home, ".claude", "projects", "proj", "session.jsonl"),
+		`{"type":"assistant","uuid":"claude-1","timestamp":"2026-05-08T02:00:00Z","cwd":"/repo","message":{"id":"msg-1","model":"claude-sonnet-4","usage":{"input_tokens":1000000,"output_tokens":1},"stop_reason":"end_turn"}}`+"\n")
+	geminiOutfile := filepath.Join(home, ".gemini", "telemetry.log")
+	writeFixture(t, filepath.Join(home, ".gemini", "settings.json"), `{"telemetry":{"enabled":true,"target":"local","outfile":"`+geminiOutfile+`","logPrompts":false}}`)
+	writeFixture(t, geminiOutfile,
+		`{"timestamp":"2026-05-08T03:00:00Z","name":"gemini_cli.api_response","attributes":{"model":"gemini-2.5-flash","auth_type":"google","input_token_count":1000000,"total_token_count":1000000}}`+"\n")
+	var out bytes.Buffer
+	cmd := New(App{Out: &out, Now: func() time.Time {
+		return time.Date(2026, 5, 8, 12, 0, 0, 0, time.UTC)
+	}})
+	cmd.SetArgs([]string{"--home", home, "--pricing", pricingPath, "--no-version-check", "summary", "--period", "today", "--format", "json", "--group-by", "model"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	var payload report.Payload
+	if err := json.Unmarshal(out.Bytes(), &payload); err != nil {
+		t.Fatalf("summary json should be valid: %v\n%s", err, out.String())
+	}
+	got := map[string]float64{}
+	for _, result := range payload.Results {
+		got[result.Key["model"]] = result.CostUSD
+	}
+	if got["gpt-5.4"] != 2 {
+		t.Fatalf("gpt-5.4 cost = %.4f, want 2; payload=%+v", got["gpt-5.4"], payload.Results)
+	}
+	if got["claude-sonnet-4"] != 3 {
+		t.Fatalf("claude-sonnet-4 cost = %.4f, want 3; payload=%+v", got["claude-sonnet-4"], payload.Results)
+	}
+	if got["gemini-2.5-flash"] != 0.3 {
+		t.Fatalf("gemini-2.5-flash cost = %.4f, want 0.3; payload=%+v", got["gemini-2.5-flash"], payload.Results)
+	}
+}
+
 func TestSummaryShowsDifferentPricesForModelProviderPairs(t *testing.T) {
 	home := t.TempDir()
 	writeFixture(t, filepath.Join(home, ".aitok", "pricing.json"), `{"models":[{"match":"gpt-5.4","provider":"team-a","input_usd_per_mtok":2,"output_usd_per_mtok":20,"cache_hit_usd_per_mtok":0.2,"cache_make_usd_per_mtok":2}]}`)

--- a/internal/pricing/pricing.go
+++ b/internal/pricing/pricing.go
@@ -1,6 +1,7 @@
 package pricing
 
 import (
+	"encoding/json"
 	"sort"
 	"strings"
 
@@ -27,7 +28,14 @@ type ModelPrice struct {
 }
 
 type Catalog struct {
-	Models []ModelPrice `json:"models"`
+	Models        []ModelPrice `json:"models"`
+	sortedModelsC []modelMatcher
+}
+
+type modelMatcher struct {
+	price         ModelPrice
+	matchLower    string
+	providerLower string
 }
 
 type Cost struct {
@@ -56,7 +64,7 @@ func Load(home string) (Catalog, error) {
 }
 
 func DefaultCatalog() Catalog {
-	return Catalog{Models: []ModelPrice{
+	catalog := Catalog{Models: []ModelPrice{
 		{Match: "codex-auto-review", Provider: "bcb", InputUSDPerMTok: 5, OutputUSDPerMTok: 30, CacheHitUSDPerMTok: 0.5, CacheMakeUSDPerMTok: 5, Multiplier: 1, Source: "default"},
 		{Match: "gpt-5.5", Provider: "openai", InputUSDPerMTok: 5, OutputUSDPerMTok: 30, CacheHitUSDPerMTok: 0.5, CacheMakeUSDPerMTok: 5, Multiplier: 1, Source: "default"},
 		{Match: "gpt-5.4-mini", Provider: "openai", InputUSDPerMTok: 0.75, OutputUSDPerMTok: 4.5, CacheHitUSDPerMTok: 0.075, CacheMakeUSDPerMTok: 0.75, Multiplier: 1, Source: "default"},
@@ -79,6 +87,8 @@ func DefaultCatalog() Catalog {
 		{Match: "gemini-2.5-flash", Provider: "google", InputUSDPerMTok: 0.3, OutputUSDPerMTok: 2.5, CacheHitUSDPerMTok: 0.03, CacheMakeUSDPerMTok: 0.3, Multiplier: 1, Source: "default"},
 		{Match: "gemini-2.0-flash", Provider: "google", InputUSDPerMTok: 0.1, OutputUSDPerMTok: 0.4, CacheHitUSDPerMTok: 0.025, CacheMakeUSDPerMTok: 0.1, Multiplier: 1, Source: "default"},
 	}}
+	catalog.refreshSortedModels()
+	return catalog
 }
 
 func (c Catalog) CostFor(event usage.UsageEvent) Cost {
@@ -130,58 +140,93 @@ func (c Catalog) match(event usage.UsageEvent) (ModelPrice, bool) {
 	model := strings.ToLower(event.Model)
 	provider := strings.ToLower(event.Provider)
 	models := c.sortedModels()
-	for _, price := range models {
-		if price.Provider == "" || provider == "" || !strings.Contains(provider, strings.ToLower(price.Provider)) {
+	for _, candidate := range models {
+		if candidate.providerLower == "" || provider == "" || !strings.Contains(provider, candidate.providerLower) {
 			continue
 		}
-		if strings.Contains(model, strings.ToLower(price.Match)) {
-			if price.Source == "" {
-				price.Source = "configured"
-			}
-			return price, true
+		if strings.Contains(model, candidate.matchLower) {
+			return finalizeMatchedPrice(candidate.price), true
 		}
 	}
-	for _, price := range models {
-		if price.Provider != "" {
+	for _, candidate := range models {
+		if candidate.providerLower != "" {
 			continue
 		}
-		if strings.Contains(model, strings.ToLower(price.Match)) {
-			if price.Source == "" {
-				price.Source = "configured"
-			}
-			return price, true
+		if strings.Contains(model, candidate.matchLower) {
+			return finalizeMatchedPrice(candidate.price), true
 		}
 	}
-	for _, price := range models {
-		if price.Provider == "" || price.Source != "default" {
+	for _, candidate := range models {
+		if candidate.providerLower == "" || candidate.price.Source != "default" {
 			continue
 		}
-		if strings.Contains(model, strings.ToLower(price.Match)) {
-			if price.Source == "" {
-				price.Source = "configured"
-			}
-			return price, true
+		if strings.Contains(model, candidate.matchLower) {
+			return finalizeMatchedPrice(candidate.price), true
 		}
 	}
 	return ModelPrice{}, false
 }
 
-func (c Catalog) sortedModels() []ModelPrice {
-	models := append([]ModelPrice(nil), c.Models...)
-	sort.SliceStable(models, func(i, j int) bool {
-		return len(models[i].Match) > len(models[j].Match)
+func finalizeMatchedPrice(price ModelPrice) ModelPrice {
+	if price.Source == "" {
+		price.Source = "configured"
+	}
+	return price
+}
+
+func (c Catalog) sortedModels() []modelMatcher {
+	if len(c.sortedModelsC) > 0 || len(c.Models) == 0 {
+		return c.sortedModelsC
+	}
+	matchers := make([]modelMatcher, 0, len(c.Models))
+	for _, price := range c.Models {
+		matchers = append(matchers, modelMatcher{
+			price:         price,
+			matchLower:    strings.ToLower(price.Match),
+			providerLower: strings.ToLower(price.Provider),
+		})
+	}
+	sort.SliceStable(matchers, func(i, j int) bool {
+		return len(matchers[i].price.Match) > len(matchers[j].price.Match)
 	})
-	return models
+	return matchers
+}
+
+func (c *Catalog) refreshSortedModels() {
+	c.sortedModelsC = make([]modelMatcher, 0, len(c.Models))
+	for _, price := range c.Models {
+		c.sortedModelsC = append(c.sortedModelsC, modelMatcher{
+			price:         price,
+			matchLower:    strings.ToLower(price.Match),
+			providerLower: strings.ToLower(price.Provider),
+		})
+	}
+	sort.SliceStable(c.sortedModelsC, func(i, j int) bool {
+		return len(c.sortedModelsC[i].price.Match) > len(c.sortedModelsC[j].price.Match)
+	})
+}
+
+func (c *Catalog) UnmarshalJSON(data []byte) error {
+	type rawCatalog Catalog
+	var raw rawCatalog
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	*c = Catalog(raw)
+	c.refreshSortedModels()
+	return nil
 }
 
 func (c *Catalog) upsert(price ModelPrice) {
 	for i, existing := range c.Models {
 		if strings.EqualFold(existing.Match, price.Match) && strings.EqualFold(existing.Provider, price.Provider) {
 			c.Models[i] = price
+			c.refreshSortedModels()
 			return
 		}
 	}
 	c.Models = append([]ModelPrice{price}, c.Models...)
+	c.refreshSortedModels()
 }
 
 func perMillion(tokens int64, price float64) float64 {

--- a/internal/pricing/pricing_test.go
+++ b/internal/pricing/pricing_test.go
@@ -345,3 +345,31 @@ func TestDefaultCatalogCoversCodexAutoReview(t *testing.T) {
 		t.Fatalf("source = %q, want default", cost.Source)
 	}
 }
+
+func BenchmarkCostFor(b *testing.B) {
+	catalog := DefaultCatalog()
+	events := make([]usage.UsageEvent, 4096)
+	models := []string{"gpt-5.5", "gpt-5.4", "claude-sonnet-4", "claude-opus-4-7", "gemini-2.5-flash", "gemini-2.5-pro", "codex-auto-review"}
+	providers := []string{"openai", "anthropic", "google", "bcb"}
+	for i := range events {
+		events[i] = usage.UsageEvent{
+			Tool:     usage.ToolCodex,
+			Model:    models[i%len(models)],
+			Provider: providers[i%len(providers)],
+			Usage: usage.TokenUsage{
+				Input:           int64(100_000 + i%10_000),
+				Output:          int64(10_000 + i%1_000),
+				CachedInput:     int64(50_000 + i%5_000),
+				CacheCreation:   int64(5_000 + i%500),
+				CacheCreation5m: int64(2_000 + i%200),
+				CacheCreation1h: int64(1_000 + i%100),
+			},
+		}
+	}
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		for _, event := range events {
+			_ = catalog.CostFor(event)
+		}
+	}
+}

--- a/internal/query/query.go
+++ b/internal/query/query.go
@@ -9,11 +9,29 @@ import (
 	"github.com/MagnumGoYB/aitok/internal/usage"
 )
 
+type sortableResult struct {
+	result  Result
+	sortKey string
+}
+
+type sortableThreadResult struct {
+	result     ThreadResult
+	tieBreaker string
+	sortTime   time.Time
+}
+
 type Filters struct {
 	Tools     []string
 	Models    []string
 	Providers []string
 	CWD       string
+}
+
+type filterMatcher struct {
+	tools     map[string]struct{}
+	models    map[string]struct{}
+	providers map[string]struct{}
+	cwd       string
 }
 
 type GroupBy []string
@@ -103,25 +121,25 @@ type ThreadTurn struct {
 	CostUSD             float64          `json:"cost_usd"`
 	Usage               usage.TokenUsage `json:"usage"`
 	TurnEventIndex      int              `json:"-"`
-	PriceSource         string           `json:"-"`
-	Price               *Price           `json:"-"`
 }
 
 type Accumulator struct {
-	window  Window
-	filters Filters
-	groupBy GroupBy
-	sortBy  SortMetric
-	costFor func(usage.UsageEvent) Cost
-	buckets map[string]*Result
+	window        Window
+	filters       Filters
+	filterMatcher filterMatcher
+	groupBy       GroupBy
+	sortBy        SortMetric
+	costFor       func(usage.UsageEvent) Cost
+	buckets       map[string]*Result
 }
 
 type ThreadAccumulator struct {
-	window  Window
-	filters Filters
-	sortBy  SortMetric
-	costFor func(usage.UsageEvent) Cost
-	buckets map[string]*threadBucket
+	window        Window
+	filters       Filters
+	filterMatcher filterMatcher
+	sortBy        SortMetric
+	costFor       func(usage.UsageEvent) Cost
+	buckets       map[string]*threadBucket
 }
 
 type threadBucket struct {
@@ -136,8 +154,10 @@ type threadBucket struct {
 	turnEventCounts       map[string]int
 }
 
+var defaultGroupBy = GroupBy{"tool", "model", "provider"}
+
 func DefaultGroupBy() GroupBy {
-	return GroupBy{"tool", "model", "provider"}
+	return append(GroupBy(nil), defaultGroupBy...)
 }
 
 func ParseGroupBy(raw string) GroupBy {
@@ -201,55 +221,62 @@ func NewThreadAccumulator(window Window, filters Filters, costFor func(usage.Usa
 }
 
 func NewAccumulatorWithSort(window Window, filters Filters, groupBy GroupBy, sortBy SortMetric, costFor func(usage.UsageEvent) Cost) *Accumulator {
-	return &Accumulator{window: window, filters: filters, groupBy: groupBy, sortBy: normalizeSortMetric(sortBy), costFor: costFor, buckets: map[string]*Result{}}
+	return &Accumulator{window: window, filters: filters, filterMatcher: newFilterMatcher(filters), groupBy: groupBy, sortBy: normalizeSortMetric(sortBy), costFor: costFor, buckets: map[string]*Result{}}
 }
 
 func NewThreadAccumulatorWithSort(window Window, filters Filters, sortBy SortMetric, costFor func(usage.UsageEvent) Cost) *ThreadAccumulator {
-	return &ThreadAccumulator{window: window, filters: filters, sortBy: normalizeSortMetric(sortBy), costFor: costFor, buckets: map[string]*threadBucket{}}
+	return &ThreadAccumulator{window: window, filters: filters, filterMatcher: newFilterMatcher(filters), sortBy: normalizeSortMetric(sortBy), costFor: costFor, buckets: map[string]*threadBucket{}}
 }
 
 func (a *Accumulator) Add(event usage.UsageEvent) {
-	if !a.window.Contains(event.Timestamp) || !matches(event, a.filters) {
+	if !a.window.Contains(event.Timestamp) || !a.filterMatcher.matches(event) {
 		return
 	}
 	key := keyFor(event, a.groupBy, a.window.Start.Location())
 	bucketKey := serializeKey(a.groupBy, key)
-	if a.buckets[bucketKey] == nil {
-		a.buckets[bucketKey] = &Result{Key: key, Examples: map[string]string{}}
+	bucket := a.buckets[bucketKey]
+	if bucket == nil {
+		bucket = &Result{Key: key, Examples: map[string]string{}}
+		a.buckets[bucketKey] = bucket
 	}
-	a.buckets[bucketKey].Events++
-	a.buckets[bucketKey].Requests++
-	a.buckets[bucketKey].Usage = a.buckets[bucketKey].Usage.Add(event.Usage)
+	bucket.Events++
+	bucket.Requests++
+	bucket.Usage = bucket.Usage.Add(event.Usage)
 	if a.costFor != nil {
 		cost := a.costFor(event)
-		a.buckets[bucketKey].CostUSD += cost.USD
-		a.buckets[bucketKey].PriceSource = mergePriceSource(a.buckets[bucketKey].PriceSource, cost.Source)
-		a.buckets[bucketKey].Price = mergePrice(a.buckets[bucketKey].Price, cost)
+		bucket.CostUSD += cost.USD
+		bucket.PriceSource = mergePriceSource(bucket.PriceSource, cost.Source)
+		bucket.Price = mergePrice(bucket.Price, cost)
 	}
-	if event.CWD != "" && a.buckets[bucketKey].Examples["cwd"] == "" {
-		a.buckets[bucketKey].Examples["cwd"] = event.CWD
+	if event.CWD != "" && bucket.Examples["cwd"] == "" {
+		bucket.Examples["cwd"] = event.CWD
 	}
 }
 
 func (a *Accumulator) Results() []Result {
-	results := make([]Result, 0, len(a.buckets))
+	sortable := make([]sortableResult, 0, len(a.buckets))
 	for _, result := range a.buckets {
 		if len(result.Examples) == 0 {
 			result.Examples = nil
 		}
-		results = append(results, *result)
+		sortable = append(sortable, sortableResult{result: *result, sortKey: serializeKey(a.groupBy, result.Key)})
 	}
-	sort.Slice(results, func(i, j int) bool {
-		if compareResults(results[i], results[j], a.sortBy) != 0 {
-			return compareResults(results[i], results[j], a.sortBy) < 0
+	sort.Slice(sortable, func(i, j int) bool {
+		cmp := compareResults(sortable[i].result, sortable[j].result, a.sortBy)
+		if cmp != 0 {
+			return cmp < 0
 		}
-		return serializeKey(a.groupBy, results[i].Key) < serializeKey(a.groupBy, results[j].Key)
+		return sortable[i].sortKey < sortable[j].sortKey
 	})
+	results := make([]Result, 0, len(sortable))
+	for _, item := range sortable {
+		results = append(results, item.result)
+	}
 	return results
 }
 
 func (a *ThreadAccumulator) Add(event usage.UsageEvent) {
-	if !a.window.Contains(event.Timestamp) || !matches(event, a.filters) {
+	if !a.window.Contains(event.Timestamp) || !a.filterMatcher.matches(event) {
 		return
 	}
 	id := usage.Unknown(event.ThreadID)
@@ -287,19 +314,24 @@ func (a *ThreadAccumulator) Add(event usage.UsageEvent) {
 	bucket.result.Events++
 	bucket.result.Requests++
 	bucket.result.Usage = bucket.result.Usage.Add(event.Usage)
+	var cost Cost
+	var normalizedPriceSource string
+	var normalizedPrice *Price
 	if a.costFor != nil {
-		cost := a.costFor(event)
+		cost = a.costFor(event)
+		normalizedPriceSource = mergePriceSource("", cost.Source)
+		normalizedPrice = priceFromCost(cost)
 		bucket.result.CostUSD += cost.USD
 		bucket.costByProvider[provider] += cost.USD
 		recordThreadAttribution(bucket, provider, event.ProviderAttribution, event.Usage, cost.USD)
-		recordThreadTurn(bucket, event, cost.USD, mergePriceSource("", cost.Source), priceFromCost(cost))
-		if source := priceSourceLabel(cost.Source); source != "" {
-			bucket.priceSources[source] = struct{}{}
+		recordThreadTurn(bucket, event, cost.USD)
+		if normalizedPriceSource != "" {
+			bucket.priceSources[normalizedPriceSource] = struct{}{}
 		}
-		bucket.price = mergePrice(bucket.price, cost)
+		bucket.price = mergeAggregatedPrice(bucket.price, normalizedPrice)
 	} else {
 		recordThreadAttribution(bucket, provider, event.ProviderAttribution, event.Usage, 0)
-		recordThreadTurn(bucket, event, 0, "", nil)
+		recordThreadTurn(bucket, event, 0)
 	}
 	if bucket.result.Name == "unknown" && event.ThreadName != "" {
 		bucket.result.Name = event.ThreadName
@@ -319,17 +351,21 @@ func (a *ThreadAccumulator) Add(event usage.UsageEvent) {
 	if bucket.result.LastActiveAt.IsZero() || event.Timestamp.After(bucket.result.LastActiveAt) {
 		bucket.result.LastActiveAt = event.Timestamp
 	}
-	groupKey := keyFor(event, DefaultGroupBy(), time.UTC)
-	groupBucketID := serializeKey(DefaultGroupBy(), groupKey)
-	if bucket.groupBuckets[groupBucketID] == nil {
-		bucket.groupBuckets[groupBucketID] = &Result{Key: groupKey}
+	groupKey := map[string]string{
+		"tool":     string(event.Tool),
+		"model":    model,
+		"provider": provider,
 	}
+	groupBucketID := serializeKey(defaultGroupBy, groupKey)
 	groupBucket := bucket.groupBuckets[groupBucketID]
+	if groupBucket == nil {
+		groupBucket = &Result{Key: groupKey}
+		bucket.groupBuckets[groupBucketID] = groupBucket
+	}
 	groupBucket.Events++
 	groupBucket.Requests++
 	groupBucket.Usage = groupBucket.Usage.Add(event.Usage)
 	if a.costFor != nil {
-		cost := a.costFor(event)
 		groupBucket.CostUSD += cost.USD
 		groupBucket.PriceSource = mergePriceSource(groupBucket.PriceSource, cost.Source)
 		groupBucket.Price = mergePrice(groupBucket.Price, cost)
@@ -337,7 +373,7 @@ func (a *ThreadAccumulator) Add(event usage.UsageEvent) {
 }
 
 func (a *ThreadAccumulator) Results() []ThreadResult {
-	results := make([]ThreadResult, 0, len(a.buckets))
+	sortable := make([]sortableThreadResult, 0, len(a.buckets))
 	for _, result := range a.buckets {
 		thread := result.result
 		thread.Model = summarizeValues(result.models, "unknown")
@@ -346,47 +382,62 @@ func (a *ThreadAccumulator) Results() []ThreadResult {
 		thread.AttributionBreakdown = summarizeThreadAttributions(result.attributionByProvider)
 		thread.PriceSource = summarizePriceSources(result.priceSources)
 		thread.Price = result.price
-		results = append(results, thread)
+		sortTime := thread.CreatedAt
+		if sortTime.IsZero() {
+			sortTime = thread.LastActiveAt
+		}
+		sortable = append(sortable, sortableThreadResult{
+			result:     thread,
+			tieBreaker: thread.Tool + "|" + thread.ID,
+			sortTime:   sortTime,
+		})
 	}
-	sort.Slice(results, func(i, j int) bool {
-		if compareThreads(results[i], results[j], a.sortBy) != 0 {
-			return compareThreads(results[i], results[j], a.sortBy) < 0
+	sort.Slice(sortable, func(i, j int) bool {
+		cmp := compareThreads(sortable[i].result, sortable[j].result, a.sortBy)
+		if cmp != 0 {
+			return cmp < 0
 		}
-		leftCreated := results[i].CreatedAt
-		rightCreated := results[j].CreatedAt
-		if leftCreated.IsZero() {
-			leftCreated = results[i].LastActiveAt
+		if !sortable[i].sortTime.Equal(sortable[j].sortTime) {
+			return sortable[i].sortTime.After(sortable[j].sortTime)
 		}
-		if rightCreated.IsZero() {
-			rightCreated = results[j].LastActiveAt
-		}
-		if !leftCreated.Equal(rightCreated) {
-			return leftCreated.After(rightCreated)
-		}
-		return results[i].Tool+"|"+results[i].ID < results[j].Tool+"|"+results[j].ID
+		return sortable[i].tieBreaker < sortable[j].tieBreaker
 	})
+	results := make([]ThreadResult, 0, len(sortable))
+	for _, item := range sortable {
+		results = append(results, item.result)
+	}
 	return results
 }
 
 func (a *ThreadAccumulator) GroupResults(groupBy GroupBy) []Result {
 	buckets := map[string]*Result{}
+	useDefaultGroupBy := sameGroupBy(groupBy, defaultGroupBy)
 	for _, thread := range a.buckets {
 		threadBuckets := a.groupBucketsForThread(thread, groupBy)
-		for _, groupBucket := range threadBuckets {
+		for bucketID, groupBucket := range threadBuckets {
+			if useDefaultGroupBy {
+				mergeGroupedResultByID(buckets, bucketID, groupBucket)
+				continue
+			}
 			key := regroupThreadBucketKey(groupBucket.Key, groupBy)
 			mergeGroupedResult(buckets, groupBy, key, *groupBucket)
 		}
 	}
-	results := make([]Result, 0, len(buckets))
+	sortable := make([]sortableResult, 0, len(buckets))
 	for _, bucket := range buckets {
-		results = append(results, *bucket)
+		sortable = append(sortable, sortableResult{result: *bucket, sortKey: serializeKey(groupBy, bucket.Key)})
 	}
-	sort.Slice(results, func(i, j int) bool {
-		if compareResults(results[i], results[j], a.sortBy) != 0 {
-			return compareResults(results[i], results[j], a.sortBy) < 0
+	sort.Slice(sortable, func(i, j int) bool {
+		cmp := compareResults(sortable[i].result, sortable[j].result, a.sortBy)
+		if cmp != 0 {
+			return cmp < 0
 		}
-		return serializeKey(groupBy, results[i].Key) < serializeKey(groupBy, results[j].Key)
+		return sortable[i].sortKey < sortable[j].sortKey
 	})
+	results := make([]Result, 0, len(sortable))
+	for _, item := range sortable {
+		results = append(results, item.result)
+	}
 	return results
 }
 
@@ -408,7 +459,7 @@ func (a *ThreadAccumulator) groupBucketsForThread(thread *threadBucket, groupBy 
 			"model":    usage.Unknown(item.Model),
 			"provider": usage.Unknown(item.Provider),
 		}
-		bucketID := serializeKey(DefaultGroupBy(), key)
+		bucketID := serializeKey(defaultGroupBy, key)
 		if grouped[bucketID] == nil {
 			grouped[bucketID] = &Result{
 				Key:         key,
@@ -439,6 +490,36 @@ func mergeGroupedResult(buckets map[string]*Result, groupBy GroupBy, key map[str
 	bucket.Usage = bucket.Usage.Add(next.Usage)
 	bucket.PriceSource = mergePriceSource(bucket.PriceSource, next.PriceSource)
 	bucket.Price = mergeAggregatedPrice(bucket.Price, next.Price)
+}
+
+func mergeGroupedResultByID(buckets map[string]*Result, bucketID string, next *Result) {
+	if next == nil {
+		return
+	}
+	bucket := buckets[bucketID]
+	if bucket == nil {
+		copy := *next
+		buckets[bucketID] = &copy
+		return
+	}
+	bucket.Events += next.Events
+	bucket.Requests += next.Requests
+	bucket.CostUSD += next.CostUSD
+	bucket.Usage = bucket.Usage.Add(next.Usage)
+	bucket.PriceSource = mergePriceSource(bucket.PriceSource, next.PriceSource)
+	bucket.Price = mergeAggregatedPrice(bucket.Price, next.Price)
+}
+
+func sameGroupBy(left, right GroupBy) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for i := range left {
+		if left[i] != right[i] {
+			return false
+		}
+	}
+	return true
 }
 
 func supportsProviderRebalance(groupBy GroupBy) bool {
@@ -606,8 +687,8 @@ func clonePriceComponents(components []Price) []Price {
 func threadTurnToRebalancedEvent(tool string, turn ThreadTurn, provider string, fraction float64, costFor func(usage.UsageEvent) Cost) rebalancedThreadEvent {
 	scaledUsage := scaleTokenUsage(turn.Usage, fraction)
 	costUSD := turn.CostUSD * fraction
-	priceSource := turn.PriceSource
-	price := clonePrice(turn.Price)
+	var priceSource string
+	var price *Price
 	if costFor != nil {
 		cost := costFor(usage.UsageEvent{
 			ID:                  turn.EventID,
@@ -911,17 +992,53 @@ func summarizeValues(values map[string]struct{}, fallback string) string {
 	return strings.Join(items[:2], ",") + ",..."
 }
 
-func matches(event usage.UsageEvent, filters Filters) bool {
-	if len(filters.Tools) > 0 && !contains(filters.Tools, string(event.Tool)) {
-		return false
+func newFilterMatcher(filters Filters) filterMatcher {
+	return filterMatcher{
+		tools:     buildFilterSet(filters.Tools),
+		models:    buildFilterSet(filters.Models),
+		providers: buildFilterSet(filters.Providers),
+		cwd:       strings.TrimSpace(filters.CWD),
 	}
-	if len(filters.Models) > 0 && !contains(filters.Models, event.Model) {
-		return false
+}
+
+func buildFilterSet(values []string) map[string]struct{} {
+	if len(values) == 0 {
+		return nil
 	}
-	if len(filters.Providers) > 0 && !contains(filters.Providers, event.Provider) {
-		return false
+	set := make(map[string]struct{}, len(values))
+	for _, value := range values {
+		normalized := normalizeFilterValue(value)
+		if normalized != "" {
+			set[normalized] = struct{}{}
+		}
 	}
-	if filters.CWD != "" && !strings.Contains(event.CWD, filters.CWD) {
+	if len(set) == 0 {
+		return nil
+	}
+	return set
+}
+
+func normalizeFilterValue(value string) string {
+	return strings.ToLower(strings.TrimSpace(value))
+}
+
+func (m filterMatcher) matches(event usage.UsageEvent) bool {
+	if len(m.tools) > 0 {
+		if _, ok := m.tools[normalizeFilterValue(string(event.Tool))]; !ok {
+			return false
+		}
+	}
+	if len(m.models) > 0 {
+		if _, ok := m.models[normalizeFilterValue(event.Model)]; !ok {
+			return false
+		}
+	}
+	if len(m.providers) > 0 {
+		if _, ok := m.providers[normalizeFilterValue(event.Provider)]; !ok {
+			return false
+		}
+	}
+	if m.cwd != "" && !strings.Contains(event.CWD, m.cwd) {
 		return false
 	}
 	return true
@@ -972,7 +1089,7 @@ func recordThreadAttribution(bucket *threadBucket, provider string, attribution 
 	item.Usage = item.Usage.Add(tokens)
 }
 
-func recordThreadTurn(bucket *threadBucket, event usage.UsageEvent, usd float64, priceSource string, price *Price) {
+func recordThreadTurn(bucket *threadBucket, event usage.UsageEvent, usd float64) {
 	if bucket == nil {
 		return
 	}
@@ -991,8 +1108,6 @@ func recordThreadTurn(bucket *threadBucket, event usage.UsageEvent, usd float64,
 		CostUSD:             usd,
 		Usage:               event.Usage,
 		TurnEventIndex:      bucket.turnEventCounts[id],
-		PriceSource:         priceSource,
-		Price:               clonePrice(price),
 	})
 }
 
@@ -1088,7 +1203,7 @@ func contains(values []string, target string) bool {
 }
 
 func keyFor(event usage.UsageEvent, groupBy GroupBy, loc *time.Location) map[string]string {
-	key := map[string]string{}
+	key := make(map[string]string, len(groupBy))
 	for _, group := range groupBy {
 		switch group {
 		case "tool":
@@ -1109,7 +1224,7 @@ func keyFor(event usage.UsageEvent, groupBy GroupBy, loc *time.Location) map[str
 }
 
 func serializeKey(groupBy GroupBy, key map[string]string) string {
-	var parts []string
+	parts := make([]string, 0, len(groupBy))
 	for _, group := range groupBy {
 		parts = append(parts, group+"="+key[group])
 	}

--- a/internal/query/query_bench_test.go
+++ b/internal/query/query_bench_test.go
@@ -31,3 +31,70 @@ func BenchmarkAccumulatorAdd(b *testing.B) {
 		_ = acc.Results()
 	}
 }
+
+func BenchmarkThreadAccumulatorAddAndGroupResults(b *testing.B) {
+	loc := time.UTC
+	window := Window{Start: time.Date(2026, 5, 8, 0, 0, 0, 0, loc), End: time.Date(2026, 5, 9, 0, 0, 0, 0, loc)}
+	events := make([]usage.UsageEvent, 4096)
+	for i := range events {
+		threadID := fmt.Sprintf("thread-%d", i%256)
+		provider := "openai"
+		if i%5 == 0 {
+			provider = "bcb"
+		}
+		events[i] = usage.UsageEvent{
+			ID:        fmt.Sprintf("event-%d", i),
+			TurnID:    fmt.Sprintf("turn-%d", i),
+			Timestamp: time.Date(2026, 5, 8, i%24, 0, 0, 0, loc),
+			Tool:      usage.ToolCodex,
+			Model:     fmt.Sprintf("gpt-5.%d", i%8),
+			Provider:  provider,
+			ThreadID:  threadID,
+			Usage:     usage.TokenUsage{Input: int64(100 + i%50), Output: int64(10 + i%10), Total: int64(110 + i%60)},
+		}
+	}
+	costFor := func(event usage.UsageEvent) Cost {
+		return Cost{USD: float64(event.Usage.Input) / 1_000_000, Source: "default", InputUSDPerMTok: 1}
+	}
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		acc := NewThreadAccumulator(window, Filters{}, costFor)
+		for _, event := range events {
+			acc.Add(event)
+		}
+		_ = acc.GroupResults(GroupBy{"tool", "model", "provider"})
+	}
+}
+
+func BenchmarkAccumulatorAddWithFilters(b *testing.B) {
+	loc := time.UTC
+	window := Window{Start: time.Date(2026, 5, 8, 0, 0, 0, 0, loc), End: time.Date(2026, 5, 9, 0, 0, 0, 0, loc)}
+	events := make([]usage.UsageEvent, 4096)
+	for i := range events {
+		tool := usage.ToolCodex
+		if i%3 == 0 {
+			tool = usage.ToolClaude
+		}
+		provider := "openai"
+		if i%4 == 0 {
+			provider = "team-a"
+		}
+		events[i] = usage.UsageEvent{
+			Timestamp: time.Date(2026, 5, 8, i%24, 0, 0, 0, loc),
+			Tool:      tool,
+			Model:     fmt.Sprintf("gpt-5.%d", i%8),
+			Provider:  provider,
+			CWD:       fmt.Sprintf("/repo/%d/service", i%16),
+			Usage:     usage.TokenUsage{Input: int64(100 + i%50), Output: int64(10 + i%10)},
+		}
+	}
+	filters := Filters{Tools: []string{"codex"}, Models: []string{"gpt-5.4", "gpt-5.5"}, Providers: []string{"openai", "team-a"}, CWD: "/repo/1"}
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		acc := NewAccumulator(window, filters, GroupBy{"tool", "model", "provider", "cwd"}, nil)
+		for _, event := range events {
+			acc.Add(event)
+		}
+		_ = acc.Results()
+	}
+}

--- a/internal/query/query_test.go
+++ b/internal/query/query_test.go
@@ -1,11 +1,23 @@
 package query
 
 import (
+	"reflect"
 	"testing"
 	"time"
 
 	"github.com/MagnumGoYB/aitok/internal/usage"
 )
+
+func TestDefaultGroupByReturnsIndependentSlice(t *testing.T) {
+	first := DefaultGroupBy()
+	first[0] = "cwd"
+
+	got := DefaultGroupBy()
+	want := GroupBy{"tool", "model", "provider"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("DefaultGroupBy() = %#v, want %#v", got, want)
+	}
+}
 
 func TestAggregateFiltersAndGroups(t *testing.T) {
 	loc := time.UTC

--- a/internal/sources/codex.go
+++ b/internal/sources/codex.go
@@ -19,6 +19,11 @@ type Codex struct {
 	providerTimeline codexProviderTimeline
 }
 
+type codexSessionFile struct {
+	path string
+	meta threadMeta
+}
+
 func NewCodex(opts Options) Codex {
 	return Codex{Home: cleanHome(opts.Home), WindowStart: opts.WindowStart, WindowEnd: opts.WindowEnd}
 }
@@ -41,60 +46,48 @@ func (c Codex) Scan(ctx context.Context, handle func(usage.UsageEvent) error) er
 		filepath.Join(c.Home, ".codex", "sessions"),
 		filepath.Join(c.Home, ".codex", "archived_sessions"),
 	}
-	targets := c.collectProviderThreads(ctx, roots)
+	sessionFiles, targets, err := c.collectSessionFiles(ctx, roots)
+	if err != nil {
+		return err
+	}
 	c.providerTimeline = readCodexProviderTimeline(ctx, c.Home, targets)
 	index := readCodexSessionIndex(filepath.Join(c.Home, ".codex", "session_index.jsonl"))
 	seen := map[string]struct{}{}
-	for _, root := range roots {
-		err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
-			if err != nil || d == nil || d.IsDir() || filepath.Ext(path) != ".jsonl" {
-				return nil
+	for _, file := range sessionFiles {
+		meta := file.meta
+		if title := index[meta.ID]; title != "" {
+			meta.Name = chooseThreadTitle(title, meta.Name)
+		}
+		state := codexState{provider: "unknown", model: "unknown", thread: meta}
+		var pending *codexBufferedTurn
+		var turns []*codexBufferedTurn
+		readErr := readJSONLines(ctx, file.path, func(obj map[string]any) error {
+			if pending != nil && codexTurnContextBoundaryID(obj) != "" && codexTurnContextBoundaryID(obj) != pending.id {
+				turns = append(turns, pending)
+				pending = nil
 			}
-			if !c.fileMayOverlapWindow(path) {
-				return nil
-			}
-			meta := parseCodexThreadMeta(path)
-			if meta.Skip {
-				return nil
-			}
-			if title := index[meta.ID]; title != "" {
-				meta.Name = chooseThreadTitle(title, meta.Name)
-			}
-			state := codexState{provider: "unknown", model: "unknown", thread: meta}
-			var pending *codexBufferedTurn
-			var turns []*codexBufferedTurn
-			readErr := readJSONLines(ctx, path, func(obj map[string]any) error {
-				if pending != nil && codexTurnContextBoundaryID(obj) != "" && codexTurnContextBoundaryID(obj) != pending.id {
+			state.update(obj)
+			event, ok := c.parseBufferedEvent(obj, &state)
+			if ok {
+				if pending != nil && event.turnID != "" && event.turnID != pending.id {
 					turns = append(turns, pending)
 					pending = nil
 				}
-				state.update(obj)
-				event, ok := c.parseBufferedEvent(obj, &state)
-				if ok {
-					if pending != nil && event.turnID != "" && event.turnID != pending.id {
-						turns = append(turns, pending)
-						pending = nil
-					}
-					pending = appendCodexBufferedTurn(pending, state, event)
-				}
-				return nil
-			})
-			if readErr != nil {
-				return readErr
-			}
-			if pending != nil {
-				turns = append(turns, pending)
-			}
-			resolved := c.resolveBufferedTurnProviders(state.thread.ID, turns)
-			for i, turn := range turns {
-				if err := c.flushBufferedTurn(path, &state, turn, resolved[i], seen, handle); err != nil {
-					return err
-				}
+				pending = appendCodexBufferedTurn(pending, state, event)
 			}
 			return nil
 		})
-		if err != nil {
-			return err
+		if readErr != nil {
+			return readErr
+		}
+		if pending != nil {
+			turns = append(turns, pending)
+		}
+		resolved := c.resolveBufferedTurnProviders(state.thread.ID, turns)
+		for i, turn := range turns {
+			if err := c.flushBufferedTurn(file.path, &state, turn, resolved[i], seen, handle); err != nil {
+				return err
+			}
 		}
 	}
 	return nil
@@ -183,10 +176,11 @@ func (c Codex) providerForBufferedEvent(threadID string, pending *codexBufferedT
 	return pending.provider, attribution
 }
 
-func (c Codex) collectProviderThreads(ctx context.Context, roots []string) codexProviderTargets {
+func (c Codex) collectSessionFiles(ctx context.Context, roots []string) ([]codexSessionFile, codexProviderTargets, error) {
 	targets := newCodexProviderTargets()
+	files := make([]codexSessionFile, 0)
 	for _, root := range roots {
-		_ = filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
 			if err := ctx.Err(); err != nil {
 				return err
 			}
@@ -197,11 +191,18 @@ func (c Codex) collectProviderThreads(ctx context.Context, roots []string) codex
 				return nil
 			}
 			meta := parseCodexThreadMeta(path)
+			if meta.Skip {
+				return nil
+			}
 			targets.addThread(meta.ID)
+			files = append(files, codexSessionFile{path: path, meta: meta})
 			return nil
 		})
+		if err != nil {
+			return nil, codexProviderTargets{}, err
+		}
 	}
-	return targets
+	return files, targets, nil
 }
 
 func (c Codex) fileMayOverlapWindow(path string) bool {

--- a/tools/commitlint/main.go
+++ b/tools/commitlint/main.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"os/exec"
 	"regexp"
 	"strings"
 	"unicode/utf8"
@@ -11,16 +12,29 @@ import (
 
 const (
 	maxHeaderLength = 64
-	formatHelp      = `emoji + " " + type + optional scope + ": " + subject`
+	formatHelp      = `type-specific emoji + " " + type + optional scope + ": " + subject`
 )
 
 var (
-	headerPattern        = regexp.MustCompile(`^(\S+)\s+([a-z]+)(?:\(([^)]+)\))?:\s+(.+)$`)
-	missingEmojiPattern  = regexp.MustCompile(`^[a-z]+(?:\([^)]+\))?:\s+.+$`)
-	allowedTypeValues    = []string{"feat", "fix", "docs", "ci", "style", "refactor", "release", "perf", "test", "chore"}
-	allowedScopeValues   = []string{"cli", "sources", "query", "report", "setup", "tui", "usage", "harness", "docs", "github", "config", "deps", "build", "tests", "release"}
-	allowedTypes         = set(allowedTypeValues...)
-	allowedScopes        = set(allowedScopeValues...)
+	headerPattern       = regexp.MustCompile(`^(\S+)\s+([a-z]+)(?:\(([^)]+)\))?:\s+(.+)$`)
+	missingEmojiPattern = regexp.MustCompile(`^[a-z]+(?:\([^)]+\))?:\s+.+$`)
+	allowedTypeValues   = []string{"feat", "fix", "docs", "ci", "style", "refactor", "release", "perf", "test", "chore", "build"}
+	allowedScopeValues  = []string{"cli", "sources", "query", "report", "setup", "tui", "usage", "harness", "docs", "github", "config", "deps", "build", "tests", "release"}
+	allowedTypes        = set(allowedTypeValues...)
+	allowedScopes       = set(allowedScopeValues...)
+	typeEmojiValues     = map[string]string{
+		"feat":     "✨",
+		"fix":      "🐛",
+		"docs":     "📝",
+		"ci":       "👷",
+		"style":    "💄",
+		"refactor": "♻️",
+		"release":  "🔖",
+		"perf":     "⚡️",
+		"test":     "✅",
+		"chore":    "🔧",
+		"build":    "🏗️",
+	}
 	allowedScopeSentinel = strings.Join([]string{
 		"cli",
 		"sources",
@@ -42,11 +56,20 @@ var (
 
 func main() {
 	editPath := flag.String("edit", "", "path to a commit message file")
+	rangeSpec := flag.String("range", "", "git commit range to validate, for example base..head")
 	flag.Parse()
 
-	if *editPath == "" {
-		fmt.Fprintln(os.Stderr, "missing --edit <commit-msg-file>")
+	if (*editPath == "" && *rangeSpec == "") || (*editPath != "" && *rangeSpec != "") {
+		fmt.Fprintln(os.Stderr, "set exactly one of --edit <commit-msg-file> or --range <base..head>")
 		os.Exit(2)
+	}
+
+	if *rangeSpec != "" {
+		if problems := lintCommitRange(*rangeSpec); len(problems) > 0 {
+			fmt.Fprintln(os.Stderr, strings.Join(problems, "\n"))
+			os.Exit(1)
+		}
+		return
 	}
 
 	data, err := os.ReadFile(*editPath)
@@ -58,6 +81,34 @@ func main() {
 		fmt.Fprintln(os.Stderr, strings.Join(problems, "\n"))
 		os.Exit(1)
 	}
+}
+
+func lintCommitRange(rangeSpec string) []string {
+	commits, err := gitOutput("log", "--format=%H", rangeSpec)
+	if err != nil {
+		return []string{err.Error()}
+	}
+	var problems []string
+	for _, commit := range strings.Fields(commits) {
+		message, err := gitOutput("log", "-1", "--format=%B", commit)
+		if err != nil {
+			problems = append(problems, err.Error())
+			continue
+		}
+		for _, problem := range lintCommitMessage(message) {
+			problems = append(problems, commit[:12]+": "+problem)
+		}
+	}
+	return problems
+}
+
+func gitOutput(args ...string) (string, error) {
+	cmd := exec.Command("git", args...)
+	data, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("git %s failed: %v\n%s", strings.Join(args, " "), err, strings.TrimSpace(string(data)))
+	}
+	return string(data), nil
 }
 
 func lintCommitMessage(message string) []string {
@@ -85,6 +136,8 @@ func lintCommitMessage(message string) []string {
 	}
 	if !allowedTypes[commitType] {
 		problems = append(problems, "type must be one of: "+strings.Join(allowedTypeValues, ", "))
+	} else if !emojiMatchesType(emoji, commitType) {
+		problems = append(problems, fmt.Sprintf("emoji must match type %q; expected: %s", commitType, typeEmojiValues[commitType]))
 	}
 	if scope != "" && !allowedScopes[scope] {
 		problems = append(problems, "scope must be one of: "+allowedScopeSentinel)
@@ -108,7 +161,11 @@ func firstNonCommentLine(message string) string {
 
 func looksLikeEmoji(value string) bool {
 	r, _ := utf8.DecodeRuneInString(value)
-	return r >= 0x1F000 || strings.ContainsRune(value, '✨') || strings.ContainsRune(value, '♻')
+	return r >= 0x1F000 || strings.ContainsAny(value, "✨♻⚡✅")
+}
+
+func emojiMatchesType(emoji string, commitType string) bool {
+	return emoji == typeEmojiValues[commitType]
 }
 
 func set(values ...string) map[string]bool {

--- a/tools/commitlint/main_test.go
+++ b/tools/commitlint/main_test.go
@@ -7,10 +7,17 @@ import (
 
 func TestLintCommitMessageAcceptsEmojiConventionalHeader(t *testing.T) {
 	for _, message := range []string{
-		"🚧 chore(harness): add commit workflow",
+		"🔧 chore(harness): add commit workflow",
 		"✨ feat(cli): add summary flag\n\nBody text.",
+		"🐛 fix(query): preserve aggregation result",
+		"⚡️ perf(query): reduce allocations",
+		"✅ test(query): guard default grouping",
 		"📝 docs: update readme",
 		"♻️ refactor(sources): simplify parser",
+		"👷 ci(github): validate every commit",
+		"💄 style(tui): align spacing",
+		"🔖 release: v0.1.33",
+		"🏗️ build(deps): update build metadata",
 	} {
 		if problems := lintCommitMessage(message); len(problems) > 0 {
 			t.Fatalf("expected %q to pass, got %v", message, problems)
@@ -19,13 +26,21 @@ func TestLintCommitMessageAcceptsEmojiConventionalHeader(t *testing.T) {
 }
 
 func TestLintCommitMessageRejectsMalformedHeaders(t *testing.T) {
+	barePerfEmoji := "⚡"
+	bareRefactorEmoji := "♻"
+	bareBuildEmoji := "🏗"
 	cases := map[string]string{
-		"chore(harness): missing emoji":                "header must start with an emoji",
-		"🚧 unknown(harness): bad type":                 "type must be one of:",
-		"🚧 chore(other): bad scope":                    "scope must be one of:",
-		"🚧 chore(harness) missing colon":               "header must match",
-		"# comment only\n\n":                           "commit message header is empty",
-		"🚧 chore(harness): " + strings.Repeat("x", 80): "header must be 64 characters or fewer",
+		"chore(harness): missing emoji":                   "header must start with an emoji",
+		"🚧 unknown(harness): bad type":                    "type must be one of:",
+		"✨ test(query): wrong emoji":                      "emoji must match type \"test\"",
+		barePerfEmoji + " perf(query): missing selector":  "emoji must match type \"perf\"",
+		bareRefactorEmoji + " refactor(query): selector":  "emoji must match type \"refactor\"",
+		bareBuildEmoji + " build(deps): missing selector": "emoji must match type \"build\"",
+		"🚧 chore(harness): wrong emoji":                   "emoji must match type \"chore\"",
+		"🚧 chore(other): bad scope":                       "scope must be one of:",
+		"🚧 chore(harness) missing colon":                  "header must match",
+		"# comment only\n\n":                              "commit message header is empty",
+		"🚧 chore(harness): " + strings.Repeat("x", 80):    "header must be 64 characters or fewer",
 	}
 	for message, expected := range cases {
 		problems := lintCommitMessage(message)


### PR DESCRIPTION
## Summary

- reduce shared query and pricing hot-path overhead and trim thread aggregation allocations
- avoid repeated Codex session traversal so local `this-month` summaries spend less time in source scanning
- add per-model pricing accuracy coverage plus pricing/query benchmarks to measure current hot paths
- harden commit governance so PR CI validates every PR commit and commit emoji must match the commit type

## Requirement Classification

- Type: refactor / engineering-performance improvement / harness-tooling
- User-visible outcome: faster local `summary --period this-month --format json --no-version-check` without changing query results; stricter PR commit-message governance
- Target platform(s): CLI on all supported platforms; GitHub PR automation
- Scope assumptions: preserve existing aggregation, provider attribution, and per-model pricing semantics while improving performance; keep governance changes repository-local and executable

## Acceptance Criteria

- [x] Criteria are written before implementation starts.
- [x] Each criterion maps to unit test coverage where practical.
- [x] Each criterion maps to CLI/manual/platform evidence where relevant.
- [x] At least one failure or edge case is covered, or a reason is documented.

## Changed Areas

- `internal/pricing/pricing.go`
- `internal/pricing/pricing_test.go`
- `internal/query/query.go`
- `internal/query/query_test.go`
- `internal/query/query_bench_test.go`
- `internal/sources/codex.go`
- `internal/cli/cli_test.go`
- `tools/commitlint/`
- `harness/architecture_test.go`
- `.github/workflows/pr.yml`
- `Makefile`
- `AGENTS.md`
- `AGENTS.zh-CN.md`
- `docs/harness-engineering.md`
- `docs/zh-CN/harness-engineering.md`
- `docs/iteration-notes/2026-05-09-agent-cost-governance.md`
- `docs/zh-CN/iteration-notes/2026-05-09-agent-cost-governance.md`

## Release Decision

- Release not required: engineering/process-only performance and governance work with no intended product behavior change.

## TDD / Test Evidence

- Test/sensor added before implementation:
  - added `TestSummaryPerModelPricingStaysAccurate`
  - added `TestDefaultGroupByReturnsIndependentSlice`
  - added commitlint type-specific emoji acceptance/rejection tests
  - added harness coverage for PR range commitlint
  - added `BenchmarkCostFor`
  - added `BenchmarkThreadAccumulatorAddAndGroupResults`
  - added `BenchmarkAccumulatorAddWithFilters`
- Unit tests:
  - `make test-packages PKGS="./tools/commitlint ./harness ./internal/pricing ./internal/query ./internal/cli ./internal/sources"`
  - `make test-packages PKGS="./internal/pricing ./internal/query ./internal/cli ./internal/sources"`
- CLI/manual/platform evidence:
  - local `summary --period this-month --format json --no-version-check` baseline avg: `30.64s`
  - optimized branch avg after query/pricing/source work: `29.32s`
  - net local improvement: about `4.3%`
  - `main` vs PR `summary --period this-month --format json --group-by tool,model,provider` semantic JSON comparison passed with `generated_at` ignored and floats within `1e-12`
- Failure and edge cases covered:
  - preserved mixed price handling, provider rebalance behavior, thread baseline grouping, and per-model pricing accuracy in CLI/query tests
  - guarded `DefaultGroupBy()` against caller mutation
  - rejected wrong emoji/type pairs such as `✨ test`, bare `⚡ perf`, bare `♻ refactor`, and bare `🏗 build`
- Acceptance criteria evidence map:
  - correctness preserved by targeted package tests and semantic JSON comparison
  - performance measured by query/pricing benchmarks and repeated local `this-month` runs
  - governance enforced by `make commitlint-range COMMIT_RANGE="origin/main..HEAD"` and hosted PR metadata checks

## Validation

- [x] `make check`
- [x] `make test-harness`
- [x] `make build`
- [x] `make commitlint-range COMMIT_RANGE="origin/main..HEAD"`
- [x] `make test-packages PKGS="./tools/commitlint ./harness ./internal/pricing ./internal/query ./internal/cli ./internal/sources"`
- [x] GitHub PR checks: metadata, test, and cross-platform build all passed
- Skipped validation and reason:
  - full local `make test` after governance rewrite was not rerun; GitHub `test` passed and local targeted packages cover changed production/tooling areas

## Risk and Rollback

- Risk:
  - low to medium; changes touch shared query/pricing paths and Codex scanning, but keep output semantics unchanged and are covered by targeted tests and semantic JSON comparison
  - low governance risk; PR commitlint now checks every PR commit and each type has exactly one allowed emoji
- Rollback:
  - revert commits `591ddd6` and `ae68cca`
- Residual risk:
  - benchmark noise can obscure small gains; real-user performance may vary with local log mix even though correctness checks passed
