### PR TITLE
fix: respect Chatgpt auth mode in provider split

### DIFF
--- a/internal/sources/codex_provider_logs.go
+++ b/internal/sources/codex_provider_logs.go
@@ -55,6 +55,8 @@ var (
 	codexConnectURLPattern     = regexp.MustCompile(`starting new connection: (https?://[^\s]+)`)
 	codexHostSomePattern       = regexp.MustCompile(`host=Some\("([^"]+)"\)`)
 	codexPoolHostPattern       = regexp.MustCompile(`\("https", ([^)]+)\)`)
+	codexAuthModeQuotedPattern = regexp.MustCompile(`auth_mode="([^"]+)"`)
+	codexAuthModeSomePattern   = regexp.MustCompile(`auth_mode=Some\(([^)]+)\)`)
 	codexRequestEvidenceTokens = []string{
 		"model_client.",
 		"endpoint_session.",
@@ -65,16 +67,19 @@ var (
 		"Http::connect;",
 		"checkout waiting for idle connection",
 		"Turn error:",
+		"auth_mode=",
 	}
 	codexTrustedSQLiteProviderTargets = map[string]struct{}{
 		"codex_api::sse::responses":                 {},
 		"codex_client::default_client":              {},
 		"codex_client::transport":                   {},
+		"codex_otel.log_only":                       {},
+		"codex_otel.trace_safe":                     {},
+		"feedback_tags":                             {},
 		"hyper_util::client::legacy::connect::http": {},
 	}
 	codexIgnoredTextLogProviderTargets = map[string]struct{}{
 		"codex_core::stream_events_utils": {},
-		"codex_otel.log_only":             {},
 	}
 	codexIgnoredRequestEvidenceSubstrings = []string{
 		`run_turn:list_models`,
@@ -85,6 +90,7 @@ var (
 const (
 	codexProviderStrengthWeak   = 1
 	codexProviderStrengthStrong = 2
+	codexProviderStrengthAuth   = 3
 )
 
 func newCodexProviderTargets() codexProviderTargets {
@@ -227,16 +233,29 @@ func (t codexProviderTimeline) exactProviderForTurn(threadID, turnID string) (st
 		return "", false
 	}
 	var provider string
+	var bestStrength int
 	var found bool
+	var ambiguous bool
 	for _, point := range t[threadID] {
 		if point.TurnID != turnID {
 			continue
 		}
 		found = true
-		if provider != "" && provider != point.Provider {
-			return "", true
+		if point.Strength > bestStrength {
+			bestStrength = point.Strength
+			provider = point.Provider
+			ambiguous = false
+			continue
 		}
-		provider = point.Provider
+		if point.Strength < bestStrength {
+			continue
+		}
+		if provider != "" && provider != point.Provider {
+			ambiguous = true
+		}
+	}
+	if ambiguous {
+		return "", true
 	}
 	return provider, found
 }
@@ -461,7 +480,7 @@ func readCodexSQLiteProviderTimeline(ctx context.Context, path string, matcher c
 		if shouldIgnoreCodexRequestEvidence(row.Body) {
 			continue
 		}
-		provider := providerFromCodexRequestEvidence(row.Body, matcher)
+		provider, strength := providerFromCodexRequestEvidence(row.Body, matcher)
 		if provider == "" {
 			continue
 		}
@@ -473,7 +492,7 @@ func readCodexSQLiteProviderTimeline(ctx context.Context, path string, matcher c
 			At:       time.Unix(row.TS, row.TSNanos).UTC(),
 			TurnID:   turnID,
 			Provider: provider,
-			Strength: codexProviderStrengthStrong,
+			Strength: strength,
 		})
 	}
 	return timeline
@@ -501,6 +520,8 @@ func codexSQLiteProviderQuery(matcher codexProviderMatcher, targets codexProvide
 	}
 	sort.Strings(hostFilters)
 	sort.Strings(bodyThreadFilters)
+	providerFilters := append([]string{}, hostFilters...)
+	providerFilters = append(providerFilters, "feedback_log_body like '%auth_mode=%'")
 	trustedTargets := make([]string, 0, len(codexTrustedSQLiteProviderTargets))
 	for target := range codexTrustedSQLiteProviderTargets {
 		trustedTargets = append(trustedTargets, "'"+strings.ReplaceAll(target, "'", "''")+"'")
@@ -513,7 +534,7 @@ where (
     or (` + strings.Join(bodyThreadFilters, " or ") + `)
   )
   and target in (` + strings.Join(trustedTargets, ",") + `)
-  and (` + strings.Join(hostFilters, " or ") + `)
+  and (` + strings.Join(providerFilters, " or ") + `)
   and feedback_log_body not like '%ToolCall:%'
   and (
     feedback_log_body like '%model_client.%'
@@ -525,6 +546,7 @@ where (
     or feedback_log_body like '%Http::connect;%'
     or feedback_log_body like '%checkout waiting for idle connection%'
     or feedback_log_body like '%Turn error:%'
+    or feedback_log_body like '%auth_mode=%'
   )
 order by ts;`
 }
@@ -554,7 +576,7 @@ func addCodexProviderPointFromLogLine(timeline codexProviderTimeline, line strin
 	if err != nil {
 		return
 	}
-	provider := providerFromCodexRequestEvidence(line, matcher)
+	provider, strength := providerFromCodexRequestEvidence(line, matcher)
 	if provider == "" {
 		return
 	}
@@ -562,21 +584,50 @@ func addCodexProviderPointFromLogLine(timeline codexProviderTimeline, line strin
 		At:       ts,
 		TurnID:   turnID,
 		Provider: provider,
-		Strength: codexProviderStrengthForLogLine(line),
+		Strength: maxCodexProviderStrength(strength, codexProviderStrengthForLogLine(line)),
 	})
 }
 
-func providerFromCodexRequestEvidence(line string, matcher codexProviderMatcher) string {
+func providerFromCodexRequestEvidence(line string, matcher codexProviderMatcher) (string, int) {
+	if provider := providerFromCodexAuthMode(line); provider != "" {
+		return provider, codexProviderStrengthAuth
+	}
 	rawURL, host := extractCodexRequestURLAndHost(line)
 	if rawURL != "" {
 		if provider := matcher.providerForURL(rawURL); provider != "" {
-			return provider
+			return provider, codexProviderStrengthStrong
 		}
 	}
 	if host == "" {
+		return "", 0
+	}
+	provider := matcher.hostProviders[host]
+	if provider == "" {
+		return "", 0
+	}
+	return provider, codexProviderStrengthStrong
+}
+
+func providerFromCodexAuthMode(line string) string {
+	authMode := extractCodexAuthMode(line)
+	switch {
+	case strings.EqualFold(authMode, "Chatgpt"):
+		return "openai"
+	default:
 		return ""
 	}
-	return matcher.hostProviders[host]
+}
+
+func extractCodexAuthMode(line string) string {
+	for _, pattern := range []*regexp.Regexp{
+		codexAuthModeQuotedPattern,
+		codexAuthModeSomePattern,
+	} {
+		if match := pattern.FindStringSubmatch(line); len(match) == 2 {
+			return strings.TrimSpace(match[1])
+		}
+	}
+	return ""
 }
 
 func (m codexProviderMatcher) providerForURL(rawURL string) string {
@@ -667,6 +718,13 @@ func codexProviderStrengthForLogLine(line string) int {
 		return codexProviderStrengthWeak
 	}
 	return codexProviderStrengthStrong
+}
+
+func maxCodexProviderStrength(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
 }
 
 func codexTextLogProviderTarget(line string) string {

--- a/internal/sources/sources_test.go
+++ b/internal/sources/sources_test.go
@@ -310,6 +310,72 @@ base_url = "https://team-b.example"
 	}
 }
 
+func TestCodexPrefersChatgptAuthModeOverConfiguredProviderHost(t *testing.T) {
+	home := t.TempDir()
+	mustWrite(t, filepath.Join(home, ".codex", "config.toml"), `
+[model_providers]
+[model_providers.toska]
+name = "toska"
+base_url = "https://api.toskaxy.xyz/v1"
+`)
+	sessionDir := filepath.Join(home, ".codex", "sessions", "2026", "05", "08")
+	mustMkdir(t, sessionDir)
+	body := `{"type":"session_meta","timestamp":"2026-05-08T01:00:00Z","payload":{"id":"019e0000-0000-7000-8000-000000000188","model_provider":"toska","cwd":"/repo"}}` + "\n" +
+		`{"type":"turn_context","timestamp":"2026-05-08T01:00:01Z","payload":{"id":"turn-a","model":"gpt-5.4","cwd":"/repo"}}` + "\n" +
+		`{"type":"event_msg","timestamp":"2026-05-08T01:00:02Z","payload":{"type":"token_count","info":{"last_token_usage":{"input_tokens":100,"total_tokens":100}}}}` + "\n"
+	mustWrite(t, filepath.Join(sessionDir, "rollout-2026-05-08T09-00-00-019e0000-0000-7000-8000-000000000188.jsonl"), body)
+	logDir := filepath.Join(home, ".codex", "log")
+	mustMkdir(t, logDir)
+	mustWrite(t, filepath.Join(logDir, "codex-tui.log"), "")
+	sqlitePath := filepath.Join(home, ".codex", "logs_2.sqlite")
+	mustWriteSQLite(t, sqlitePath, []string{
+		`create table logs (
+			id integer primary key autoincrement,
+			ts integer not null,
+			ts_nanos integer not null,
+			level text not null,
+			target text not null,
+			feedback_log_body text,
+			module_path text,
+			file text,
+			line integer,
+			thread_id text,
+			process_uuid text,
+			estimated_bytes integer not null default 0
+		);`,
+		`insert into logs (ts, ts_nanos, level, target, feedback_log_body, thread_id) values (
+			1746666001,
+			0,
+			'INFO',
+			'codex_client::default_client',
+			'session_loop:turn{otel.name="session_task.turn" thread.id=019e0000-0000-7000-8000-000000000188 turn.id=turn-a model=gpt-5.4}:run_turn:run_sampling_request: Request completed method=POST url=https://api.toskaxy.xyz/v1/responses status=200 OK',
+			null
+		);`,
+		`insert into logs (ts, ts_nanos, level, target, feedback_log_body, thread_id) values (
+			1746666001,
+			500000000,
+			'INFO',
+			'codex_otel.log_only',
+			'session_loop:turn{otel.name="session_task.turn" thread.id=019e0000-0000-7000-8000-000000000188 turn.id=turn-a model=gpt-5.4}:model_client.stream_responses_api:endpoint_session.stream_with:event.name="codex.api_request" auth_mode="Chatgpt" model=gpt-5.4 slug=gpt-5.4',
+			null
+		);`,
+	})
+
+	events, err := NewCodex(Options{Home: home}).Read(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("len(events) = %d, want 1", len(events))
+	}
+	if events[0].Provider != "openai" {
+		t.Fatalf("auth_mode should override configured provider host: %+v", events[0])
+	}
+	if events[0].ProviderAttribution != string(usage.ProviderAttributionExactRequest) {
+		t.Fatalf("auth_mode attribution = %q, want exact_request", events[0].ProviderAttribution)
+	}
+}
+
 func TestCodexUsesConfigBaseURLWhenProvidersShareHost(t *testing.T) {
 	home := t.TempDir()
 	mustWrite(t, filepath.Join(home, ".codex", "config.toml"), `


### PR DESCRIPTION
## Summary

- fix Codex provider split so `auth_mode=Chatgpt` turns are attributed to `openai` even when the session or request host points at another configured provider
- read trusted sqlite auth-mode evidence from `codex_otel.*` and `feedback_tags`, then prefer auth evidence over host-only inference within the same turn
- add a sqlite regression test for the real mixed `toska` host plus `Chatgpt` auth-mode case

## Requirement Classification

- Type: bugfix
- User-visible outcome: Codex summaries, thread breakdowns, and cost splits stop misclassifying ChatGPT personal-subscription turns as a configured provider such as `toska`
- Target platform(s): CLI / JSON / threads output on all supported platforms
- Scope assumptions: use only explicit local log metadata such as `auth_mode` and request host; do not infer provider from API keys or other secrets

## Acceptance Criteria

- [x] Criteria are written before implementation starts.
- [x] Each criterion maps to unit test coverage where practical.
- [x] Each criterion maps to CLI/manual/platform evidence where relevant.
- [x] At least one failure or edge case is covered, or a reason is documented.

## Changed Areas

- `internal/sources/codex_provider_logs.go`
- `internal/sources/sources_test.go`

## Release Decision

- Release required after merge: this bugfix changes user-visible Codex provider attribution and downstream cost reporting, so it should continue into the next patch release flow after merge.

## TDD / Test Evidence

- Test/sensor added before implementation:
  - reproduced the failure against the real local thread `019e313e-d7f5-7331-ad54-f296dc232d9a` and added `TestCodexPrefersChatgptAuthModeOverConfiguredProviderHost` before final verification
- Unit tests:
  - `make test-packages PKGS="./internal/sources ./internal/cli"`
  - `make test`
- CLI/manual/platform evidence:
  - `make run ARGS="summary --period today --tool codex --format json --threads --no-version-check"`
  - verified thread `019e313e-d7f5-7331-ad54-f296dc232d9a` now reports `provider: openai` with `provider_attribution: exact_request`
- Failure and edge cases covered:
  - same-turn conflict where sqlite contains both configured-provider host evidence and `auth_mode="Chatgpt"`
  - host-only rows still continue through the existing request-host path when auth metadata is absent
  - auth-only trusted sqlite rows are now queryable even when the provider host is missing from the row body
- Acceptance criteria evidence map:
  - provider precedence correctness is covered by the new sqlite regression test and existing provider-timeline tests
  - CLI-visible output is covered by the local summary smoke on the real failing thread
  - regression safety across the wider repo is covered by `make validate`

## Validation

- [x] `make check`
- [x] `make test`
- [x] `make test-harness`
- [x] `make build`
- [x] Commit message follows `go run ./tools/commitlint --edit <commit-msg-file>`
- [x] `make validate`
- Skipped validation and reason:
  - none

## Risk and Rollback

- Risk:
  - low to medium; the change touches shared Codex provider attribution logic and trusted sqlite target selection
- Rollback:
  - revert commit `b85a337`
- Residual risk:
  - current auth-mode mapping is intentionally conservative and only upgrades the known `Chatgpt -> openai` case; other future auth modes may still need explicit mapping if Codex introduces more variants
