### PR TITLE
✨ feat(reasonix): add Reasonix source with DeepSeek CNY pricing

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -408,7 +408,7 @@ type budgetExceededError struct {
 }
 
 func (e budgetExceededError) Error() string {
-	return fmt.Sprintf("budget exceeded: total %s > limit %s", report.FormatUSD(e.Total), report.FormatUSD(e.Limit))
+	return fmt.Sprintf("budget exceeded: total %s > limit %s", report.FormatCost(e.Total, ""), report.FormatCost(e.Limit, ""))
 }
 
 func buildBudgetCheck(ctx context.Context, f *flags, now time.Time) (report.BudgetPayload, error) {
@@ -447,14 +447,19 @@ func buildBudgetCheck(ctx context.Context, f *flags, now time.Time) (report.Budg
 	}
 	results := acc.Results()
 	var total float64
+	var currency string
 	for _, result := range results {
 		total += result.CostUSD
+		if currency == "" && result.Price != nil && result.Price.Currency != "" {
+			currency = result.Price.Currency
+		}
 	}
 	return report.BudgetPayload{
 		GeneratedAt:    now,
 		Window:         window,
 		LimitUSD:       f.limitUSD,
 		TotalUSD:       total,
+		Currency:       currency,
 		Exceeded:       total > f.limitUSD,
 		UnpricedEvents: unpriced.Events,
 		UnpricedTokens: unpriced.Tokens,

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -480,6 +480,7 @@ func buildBudgetCheck(ctx context.Context, f *flags, now time.Time) (report.Budg
 func queryCost(cost pricing.Cost) query.Cost {
 	return query.Cost{
 		USD:                   cost.USD,
+		Amount:                cost.Amount,
 		Currency:              cost.Currency,
 		Source:                cost.Source,
 		InputUSDPerMTok:       cost.InputUSDPerMTok,

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -465,6 +465,7 @@ func buildBudgetCheck(ctx context.Context, f *flags, now time.Time) (report.Budg
 func queryCost(cost pricing.Cost) query.Cost {
 	return query.Cost{
 		USD:                   cost.USD,
+		Currency:              cost.Currency,
 		Source:                cost.Source,
 		InputUSDPerMTok:       cost.InputUSDPerMTok,
 		OutputUSDPerMTok:      cost.OutputUSDPerMTok,

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -446,21 +446,31 @@ func buildBudgetCheck(ctx context.Context, f *flags, now time.Time) (report.Budg
 		return report.BudgetPayload{}, err
 	}
 	results := acc.Results()
-	var total float64
-	var currency string
+	var totalUSD float64
+	var nonUSDTotal float64
+	var nonUSDCurrency string
 	for _, result := range results {
-		total += result.CostUSD
-		if currency == "" && result.Price != nil && result.Price.Currency != "" {
-			currency = result.Price.Currency
+		cur := ""
+		if result.Price != nil {
+			cur = result.Price.Currency
+		}
+		if cur == "" || strings.EqualFold(cur, "USD") {
+			totalUSD += result.CostUSD
+		} else {
+			nonUSDTotal += result.CostUSD
+			if nonUSDCurrency == "" {
+				nonUSDCurrency = cur
+			}
 		}
 	}
 	return report.BudgetPayload{
 		GeneratedAt:    now,
 		Window:         window,
 		LimitUSD:       f.limitUSD,
-		TotalUSD:       total,
-		Currency:       currency,
-		Exceeded:       total > f.limitUSD,
+		TotalUSD:       totalUSD,
+		NonUSDTotal:    nonUSDTotal,
+		NonUSDCurrency: nonUSDCurrency,
+		Exceeded:       totalUSD > f.limitUSD,
 		UnpricedEvents: unpriced.Events,
 		UnpricedTokens: unpriced.Tokens,
 		Results:        results,

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -685,6 +685,23 @@ func TestBudgetCheckFailsWhenLimitExceeded(t *testing.T) {
 	}
 }
 
+func TestBudgetCheckExcludesCNYFromUSDLimit(t *testing.T) {
+	home := t.TempDir()
+	writeFixture(t, filepath.Join(home, ".reasonix", "usage.jsonl"),
+		`{"ts":1778192400000,"session":"budget-cny","model":"deepseek-v4-flash","promptTokens":1000000,"completionTokens":500000,"cacheHitTokens":0,"cacheMissTokens":0}`+"\n")
+	var out bytes.Buffer
+	cmd := New(App{Out: &out, Now: func() time.Time {
+		return time.Date(2026, 5, 8, 12, 0, 0, 0, time.UTC)
+	}})
+	cmd.SetArgs([]string{"--home", home, "--no-version-check", "budget", "check", "--period", "today", "--limit-usd", "1", "--format", "json"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("CNY-only usage should not exceed USD budget: %v\n%s", err, out.String())
+	}
+	if !strings.Contains(out.String(), `"total_usd": 0`) || !strings.Contains(out.String(), `"non_usd_total": 2`) || !strings.Contains(out.String(), `"non_usd_currency": "CNY"`) {
+		t.Fatalf("budget output should keep CNY separate from USD: %s", out.String())
+	}
+}
+
 func TestAgentBudgetExceededKeepsPayloadOnStdoutAndSummaryOnStderr(t *testing.T) {
 	home := t.TempDir()
 	writeFixture(t, filepath.Join(home, ".codex", "sessions", "2026", "05", "08", "rollout.jsonl"),

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -688,7 +688,7 @@ func TestBudgetCheckFailsWhenLimitExceeded(t *testing.T) {
 func TestBudgetCheckExcludesCNYFromUSDLimit(t *testing.T) {
 	home := t.TempDir()
 	writeFixture(t, filepath.Join(home, ".reasonix", "usage.jsonl"),
-		`{"ts":1778192400000,"session":"budget-cny","model":"deepseek-v4-flash","promptTokens":1000000,"completionTokens":500000,"cacheHitTokens":0,"cacheMissTokens":0}`+"\n")
+		`{"ts":1778202000000,"session":"budget-cny","model":"deepseek-v4-flash","promptTokens":1000000,"completionTokens":500000,"cacheHitTokens":0,"cacheMissTokens":0}`+"\n")
 	var out bytes.Buffer
 	cmd := New(App{Out: &out, Now: func() time.Time {
 		return time.Date(2026, 5, 8, 12, 0, 0, 0, time.UTC)

--- a/internal/pricing/pricing.go
+++ b/internal/pricing/pricing.go
@@ -13,6 +13,7 @@ const userConfigPath = ".aitok/pricing.json"
 type ModelPrice struct {
 	Match                             string  `json:"match"`
 	Provider                          string  `json:"provider,omitempty"`
+	Currency                          string  `json:"currency,omitempty"`
 	InputUSDPerMTok                   float64 `json:"input_usd_per_mtok"`
 	OutputUSDPerMTok                  float64 `json:"output_usd_per_mtok"`
 	CacheHitUSDPerMTok                float64 `json:"cache_hit_usd_per_mtok"`
@@ -86,6 +87,10 @@ func DefaultCatalog() Catalog {
 		{Match: "gemini-2.5-pro", Provider: "google", InputUSDPerMTok: 1.25, OutputUSDPerMTok: 10, CacheHitUSDPerMTok: 0.125, CacheMakeUSDPerMTok: 1.25, PromptThresholdTokens: 200000, AboveThresholdInputUSDPerMTok: 2.5, AboveThresholdOutputUSDPerMTok: 15, AboveThresholdCacheHitUSDPerMTok: 0.25, AboveThresholdCacheMakeUSDPerMTok: 2.5, Multiplier: 1, Source: "default"},
 		{Match: "gemini-2.5-flash", Provider: "google", InputUSDPerMTok: 0.3, OutputUSDPerMTok: 2.5, CacheHitUSDPerMTok: 0.03, CacheMakeUSDPerMTok: 0.3, Multiplier: 1, Source: "default"},
 		{Match: "gemini-2.0-flash", Provider: "google", InputUSDPerMTok: 0.1, OutputUSDPerMTok: 0.4, CacheHitUSDPerMTok: 0.025, CacheMakeUSDPerMTok: 0.1, Multiplier: 1, Source: "default"},
+		{Match: "deepseek-chat", Provider: "deepseek", Currency: "CNY", InputUSDPerMTok: 1, OutputUSDPerMTok: 2, CacheHitUSDPerMTok: 0.1, CacheMakeUSDPerMTok: 1, Multiplier: 1, Source: "default"},
+		{Match: "deepseek-v4-flash", Provider: "deepseek", Currency: "CNY", InputUSDPerMTok: 1, OutputUSDPerMTok: 2, CacheHitUSDPerMTok: 0.02, CacheMakeUSDPerMTok: 1, Multiplier: 1, Source: "default"},
+		{Match: "deepseek-v4-pro", Provider: "deepseek", Currency: "CNY", InputUSDPerMTok: 3, OutputUSDPerMTok: 6, CacheHitUSDPerMTok: 0.025, CacheMakeUSDPerMTok: 3, Multiplier: 1, Source: "default"},
+		{Match: "deepseek-reasoner", Provider: "deepseek", Currency: "CNY", InputUSDPerMTok: 4, OutputUSDPerMTok: 16, CacheHitUSDPerMTok: 1, CacheMakeUSDPerMTok: 4, Multiplier: 1, Source: "default"},
 	}}
 	catalog.refreshSortedModels()
 	return catalog
@@ -111,7 +116,7 @@ func (c Catalog) CostFor(event usage.UsageEvent) Cost {
 		perMillion(cacheCreation1h, cacheMake1h)
 	return Cost{
 		USD:                   usd * multiplier,
-		Currency:              "USD",
+		Currency:              modelPriceCurrency(price),
 		Multiplier:            multiplier,
 		Source:                price.Source,
 		InputUSDPerMTok:       price.InputUSDPerMTok,
@@ -264,6 +269,13 @@ func cacheMake1hPrice(price ModelPrice) float64 {
 		return price.CacheMake1hUSDPerMTok
 	}
 	return cacheMakePrice(price)
+}
+
+func modelPriceCurrency(price ModelPrice) string {
+	if price.Currency != "" {
+		return price.Currency
+	}
+	return "USD"
 }
 
 func cacheCreationParts(tokens usage.TokenUsage) (fiveMinute int64, oneHour int64, other int64) {

--- a/internal/pricing/pricing.go
+++ b/internal/pricing/pricing.go
@@ -116,26 +116,10 @@ func (c Catalog) CostFor(event usage.UsageEvent) Cost {
 		perMillion(cacheCreation5m+cacheCreationOther, cacheMake) +
 		perMillion(cacheCreation1h, cacheMake1h)
 	native := usd * multiplier
-	amount := native
 	cur := modelPriceCurrency(price)
-	if strings.EqualFold(cur, "CNY") {
-		usdAmount := native / cnyPerUSD
-		return Cost{
-			USD:                   usdAmount,
-			Amount:                amount,
-			Currency:              cur,
-			Multiplier:            multiplier,
-			Source:                price.Source,
-			InputUSDPerMTok:       price.InputUSDPerMTok,
-			OutputUSDPerMTok:      price.OutputUSDPerMTok,
-			CacheHitUSDPerMTok:    price.CacheHitUSDPerMTok,
-			CacheMakeUSDPerMTok:   cacheMake,
-			CacheMake1hUSDPerMTok: cacheMake1h,
-		}
-	}
 	return Cost{
-		USD:                   amount,
-		Amount:                amount,
+		USD:                   native,
+		Amount:                native,
 		Currency:              cur,
 		Multiplier:            multiplier,
 		Source:                price.Source,
@@ -290,8 +274,6 @@ func cacheMake1hPrice(price ModelPrice) float64 {
 	}
 	return cacheMakePrice(price)
 }
-
-const cnyPerUSD = 7.2
 
 func modelPriceCurrency(price ModelPrice) string {
 	if price.Currency != "" {

--- a/internal/pricing/pricing.go
+++ b/internal/pricing/pricing.go
@@ -87,10 +87,10 @@ func DefaultCatalog() Catalog {
 		{Match: "gemini-2.5-pro", Provider: "google", InputUSDPerMTok: 1.25, OutputUSDPerMTok: 10, CacheHitUSDPerMTok: 0.125, CacheMakeUSDPerMTok: 1.25, PromptThresholdTokens: 200000, AboveThresholdInputUSDPerMTok: 2.5, AboveThresholdOutputUSDPerMTok: 15, AboveThresholdCacheHitUSDPerMTok: 0.25, AboveThresholdCacheMakeUSDPerMTok: 2.5, Multiplier: 1, Source: "default"},
 		{Match: "gemini-2.5-flash", Provider: "google", InputUSDPerMTok: 0.3, OutputUSDPerMTok: 2.5, CacheHitUSDPerMTok: 0.03, CacheMakeUSDPerMTok: 0.3, Multiplier: 1, Source: "default"},
 		{Match: "gemini-2.0-flash", Provider: "google", InputUSDPerMTok: 0.1, OutputUSDPerMTok: 0.4, CacheHitUSDPerMTok: 0.025, CacheMakeUSDPerMTok: 0.1, Multiplier: 1, Source: "default"},
-		{Match: "deepseek-chat", Provider: "deepseek", Currency: "CNY", InputUSDPerMTok: 1, OutputUSDPerMTok: 2, CacheHitUSDPerMTok: 0.1, CacheMakeUSDPerMTok: 1, Multiplier: 1, Source: "default"},
-		{Match: "deepseek-v4-flash", Provider: "deepseek", Currency: "CNY", InputUSDPerMTok: 1, OutputUSDPerMTok: 2, CacheHitUSDPerMTok: 0.02, CacheMakeUSDPerMTok: 1, Multiplier: 1, Source: "default"},
-		{Match: "deepseek-v4-pro", Provider: "deepseek", Currency: "CNY", InputUSDPerMTok: 3, OutputUSDPerMTok: 6, CacheHitUSDPerMTok: 0.025, CacheMakeUSDPerMTok: 3, Multiplier: 1, Source: "default"},
-		{Match: "deepseek-reasoner", Provider: "deepseek", Currency: "CNY", InputUSDPerMTok: 4, OutputUSDPerMTok: 16, CacheHitUSDPerMTok: 1, CacheMakeUSDPerMTok: 4, Multiplier: 1, Source: "default"},
+		{Match: "deepseek-chat", Provider: "deepseek", InputUSDPerMTok: 0.14, OutputUSDPerMTok: 0.28, CacheHitUSDPerMTok: 0.0028, CacheMakeUSDPerMTok: 0.14, Multiplier: 1, Source: "default"},
+		{Match: "deepseek-v4-flash", Provider: "deepseek", InputUSDPerMTok: 0.14, OutputUSDPerMTok: 0.28, CacheHitUSDPerMTok: 0.0028, CacheMakeUSDPerMTok: 0.14, Multiplier: 1, Source: "default"},
+		{Match: "deepseek-v4-pro", Provider: "deepseek", InputUSDPerMTok: 0.435, OutputUSDPerMTok: 0.87, CacheHitUSDPerMTok: 0.003625, CacheMakeUSDPerMTok: 0.435, Multiplier: 1, Source: "default"},
+		{Match: "deepseek-reasoner", Provider: "deepseek", InputUSDPerMTok: 0.55, OutputUSDPerMTok: 2.19, CacheHitUSDPerMTok: 0.14, CacheMakeUSDPerMTok: 0.55, Multiplier: 1, Source: "default"},
 	}}
 	catalog.refreshSortedModels()
 	return catalog

--- a/internal/pricing/pricing.go
+++ b/internal/pricing/pricing.go
@@ -41,6 +41,7 @@ type modelMatcher struct {
 
 type Cost struct {
 	USD                   float64 `json:"usd"`
+	Amount                float64 `json:"amount,omitempty"`
 	Currency              string  `json:"currency"`
 	Multiplier            float64 `json:"multiplier"`
 	Source                string  `json:"source"`
@@ -87,10 +88,10 @@ func DefaultCatalog() Catalog {
 		{Match: "gemini-2.5-pro", Provider: "google", InputUSDPerMTok: 1.25, OutputUSDPerMTok: 10, CacheHitUSDPerMTok: 0.125, CacheMakeUSDPerMTok: 1.25, PromptThresholdTokens: 200000, AboveThresholdInputUSDPerMTok: 2.5, AboveThresholdOutputUSDPerMTok: 15, AboveThresholdCacheHitUSDPerMTok: 0.25, AboveThresholdCacheMakeUSDPerMTok: 2.5, Multiplier: 1, Source: "default"},
 		{Match: "gemini-2.5-flash", Provider: "google", InputUSDPerMTok: 0.3, OutputUSDPerMTok: 2.5, CacheHitUSDPerMTok: 0.03, CacheMakeUSDPerMTok: 0.3, Multiplier: 1, Source: "default"},
 		{Match: "gemini-2.0-flash", Provider: "google", InputUSDPerMTok: 0.1, OutputUSDPerMTok: 0.4, CacheHitUSDPerMTok: 0.025, CacheMakeUSDPerMTok: 0.1, Multiplier: 1, Source: "default"},
-		{Match: "deepseek-chat", Provider: "deepseek", InputUSDPerMTok: 0.14, OutputUSDPerMTok: 0.28, CacheHitUSDPerMTok: 0.0028, CacheMakeUSDPerMTok: 0.14, Multiplier: 1, Source: "default"},
-		{Match: "deepseek-v4-flash", Provider: "deepseek", InputUSDPerMTok: 0.14, OutputUSDPerMTok: 0.28, CacheHitUSDPerMTok: 0.0028, CacheMakeUSDPerMTok: 0.14, Multiplier: 1, Source: "default"},
-		{Match: "deepseek-v4-pro", Provider: "deepseek", InputUSDPerMTok: 0.435, OutputUSDPerMTok: 0.87, CacheHitUSDPerMTok: 0.003625, CacheMakeUSDPerMTok: 0.435, Multiplier: 1, Source: "default"},
-		{Match: "deepseek-reasoner", Provider: "deepseek", InputUSDPerMTok: 0.55, OutputUSDPerMTok: 2.19, CacheHitUSDPerMTok: 0.14, CacheMakeUSDPerMTok: 0.55, Multiplier: 1, Source: "default"},
+		{Match: "deepseek-chat", Provider: "deepseek", Currency: "CNY", InputUSDPerMTok: 1, OutputUSDPerMTok: 2, CacheHitUSDPerMTok: 0.1, CacheMakeUSDPerMTok: 1, Multiplier: 1, Source: "default"},
+		{Match: "deepseek-v4-flash", Provider: "deepseek", Currency: "CNY", InputUSDPerMTok: 1, OutputUSDPerMTok: 2, CacheHitUSDPerMTok: 0.02, CacheMakeUSDPerMTok: 1, Multiplier: 1, Source: "default"},
+		{Match: "deepseek-v4-pro", Provider: "deepseek", Currency: "CNY", InputUSDPerMTok: 3, OutputUSDPerMTok: 6, CacheHitUSDPerMTok: 0.025, CacheMakeUSDPerMTok: 3, Multiplier: 1, Source: "default"},
+		{Match: "deepseek-reasoner", Provider: "deepseek", Currency: "CNY", InputUSDPerMTok: 4, OutputUSDPerMTok: 16, CacheHitUSDPerMTok: 1, CacheMakeUSDPerMTok: 4, Multiplier: 1, Source: "default"},
 	}}
 	catalog.refreshSortedModels()
 	return catalog
@@ -114,9 +115,28 @@ func (c Catalog) CostFor(event usage.UsageEvent) Cost {
 		perMillion(event.Usage.CachedInput, price.CacheHitUSDPerMTok) +
 		perMillion(cacheCreation5m+cacheCreationOther, cacheMake) +
 		perMillion(cacheCreation1h, cacheMake1h)
+	native := usd * multiplier
+	amount := native
+	cur := modelPriceCurrency(price)
+	if strings.EqualFold(cur, "CNY") {
+		usdAmount := native / cnyPerUSD
+		return Cost{
+			USD:                   usdAmount,
+			Amount:                amount,
+			Currency:              cur,
+			Multiplier:            multiplier,
+			Source:                price.Source,
+			InputUSDPerMTok:       price.InputUSDPerMTok,
+			OutputUSDPerMTok:      price.OutputUSDPerMTok,
+			CacheHitUSDPerMTok:    price.CacheHitUSDPerMTok,
+			CacheMakeUSDPerMTok:   cacheMake,
+			CacheMake1hUSDPerMTok: cacheMake1h,
+		}
+	}
 	return Cost{
-		USD:                   usd * multiplier,
-		Currency:              modelPriceCurrency(price),
+		USD:                   amount,
+		Amount:                amount,
+		Currency:              cur,
 		Multiplier:            multiplier,
 		Source:                price.Source,
 		InputUSDPerMTok:       price.InputUSDPerMTok,
@@ -270,6 +290,8 @@ func cacheMake1hPrice(price ModelPrice) float64 {
 	}
 	return cacheMakePrice(price)
 }
+
+const cnyPerUSD = 7.2
 
 func modelPriceCurrency(price ModelPrice) string {
 	if price.Currency != "" {

--- a/internal/pricing/pricing_test.go
+++ b/internal/pricing/pricing_test.go
@@ -346,6 +346,41 @@ func TestDefaultCatalogCoversCodexAutoReview(t *testing.T) {
 	}
 }
 
+func TestDefaultCatalogCoversDeepSeekModels(t *testing.T) {
+	catalog := DefaultCatalog()
+	for _, model := range []string{"deepseek-v4-flash", "deepseek-v4-pro", "deepseek-chat", "deepseek-reasoner"} {
+		cost := catalog.CostFor(usage.UsageEvent{
+			Tool:     usage.ToolReasonix,
+			Model:    model,
+			Provider: "deepseek",
+			Usage:    usage.TokenUsage{Input: 1_000_000, Output: 500_000},
+		})
+		if cost.USD == 0 {
+			t.Fatalf("CostFor(%q) returned $0.00", model)
+		}
+		if cost.Currency != "CNY" {
+			t.Fatalf("CostFor(%q).Currency = %q, want CNY", model, cost.Currency)
+		}
+		if cost.Source == "unknown" {
+			t.Fatalf("CostFor(%q).Source = unknown (unpriced)", model)
+		}
+		// deepseek-chat and deepseek-v4-flash share same pricing: ¥1/M in, ¥2/M out
+		if model == "deepseek-chat" || model == "deepseek-v4-flash" {
+			expected := 1.0 + 1.0 // 1M in × ¥1/M + 0.5M out × ¥2/M
+			if math.Abs(cost.USD-expected) > 0.01 {
+				t.Fatalf("CostFor(%q) = %.4f, want ~%.4f", model, cost.USD, expected)
+			}
+		}
+		// deepseek-v4-pro: ¥3/M in, ¥6/M out
+		if model == "deepseek-v4-pro" {
+			expected := 3.0 + 3.0 // 1M in × ¥3/M + 0.5M out × ¥6/M
+			if math.Abs(cost.USD-expected) > 0.01 {
+				t.Fatalf("CostFor(%q) = %.4f, want ~%.4f", model, cost.USD, expected)
+			}
+		}
+	}
+}
+
 func BenchmarkCostFor(b *testing.B) {
 	catalog := DefaultCatalog()
 	events := make([]usage.UsageEvent, 4096)

--- a/internal/pricing/pricing_test.go
+++ b/internal/pricing/pricing_test.go
@@ -358,24 +358,30 @@ func TestDefaultCatalogCoversDeepSeekModels(t *testing.T) {
 		if cost.USD == 0 {
 			t.Fatalf("CostFor(%q) returned $0.00", model)
 		}
-		if cost.Currency != "USD" {
-			t.Fatalf("CostFor(%q).Currency = %q, want USD", model, cost.Currency)
+		if cost.Currency != "CNY" {
+			t.Fatalf("CostFor(%q).Currency = %q, want CNY", model, cost.Currency)
 		}
 		if cost.Source == "unknown" {
 			t.Fatalf("CostFor(%q).Source = unknown (unpriced)", model)
 		}
-		// deepseek-chat and deepseek-v4-flash: $0.14/M in, $0.28/M out
 		if model == "deepseek-chat" || model == "deepseek-v4-flash" {
-			expected := 0.14 + 0.14 // 1M in × $0.14/M + 0.5M out × $0.28/M
-			if math.Abs(cost.USD-expected) > 0.001 {
-				t.Fatalf("CostFor(%q) = %.4f, want ~%.4f", model, cost.USD, expected)
+			expectedCNY := 1.0 + 1.0         // 1M in × ¥1/M + 0.5M out × ¥2/M
+			expectedUSD := expectedCNY / 7.2 // ≈ 0.2778
+			if math.Abs(cost.Amount-expectedCNY) > 0.01 {
+				t.Fatalf("CostFor(%q).Amount = %.4f, want ~%.4f CNY", model, cost.Amount, expectedCNY)
+			}
+			if math.Abs(cost.USD-expectedUSD) > 0.001 {
+				t.Fatalf("CostFor(%q).USD = %.4f, want ~%.4f", model, cost.USD, expectedUSD)
 			}
 		}
-		// deepseek-v4-pro: $0.435/M in, $0.87/M out
 		if model == "deepseek-v4-pro" {
-			expected := 0.435 + 0.435 // 1M in × $0.435/M + 0.5M out × $0.87/M
-			if math.Abs(cost.USD-expected) > 0.001 {
-				t.Fatalf("CostFor(%q) = %.4f, want ~%.4f", model, cost.USD, expected)
+			expectedCNY := 3.0 + 3.0         // 1M in × ¥3/M + 0.5M out × ¥6/M
+			expectedUSD := expectedCNY / 7.2 // ≈ 0.8333
+			if math.Abs(cost.Amount-expectedCNY) > 0.01 {
+				t.Fatalf("CostFor(%q).Amount = %.4f, want ~%.4f CNY", model, cost.Amount, expectedCNY)
+			}
+			if math.Abs(cost.USD-expectedUSD) > 0.001 {
+				t.Fatalf("CostFor(%q).USD = %.4f, want ~%.4f", model, cost.USD, expectedUSD)
 			}
 		}
 	}

--- a/internal/pricing/pricing_test.go
+++ b/internal/pricing/pricing_test.go
@@ -358,23 +358,23 @@ func TestDefaultCatalogCoversDeepSeekModels(t *testing.T) {
 		if cost.USD == 0 {
 			t.Fatalf("CostFor(%q) returned $0.00", model)
 		}
-		if cost.Currency != "CNY" {
-			t.Fatalf("CostFor(%q).Currency = %q, want CNY", model, cost.Currency)
+		if cost.Currency != "USD" {
+			t.Fatalf("CostFor(%q).Currency = %q, want USD", model, cost.Currency)
 		}
 		if cost.Source == "unknown" {
 			t.Fatalf("CostFor(%q).Source = unknown (unpriced)", model)
 		}
-		// deepseek-chat and deepseek-v4-flash share same pricing: ¥1/M in, ¥2/M out
+		// deepseek-chat and deepseek-v4-flash: $0.14/M in, $0.28/M out
 		if model == "deepseek-chat" || model == "deepseek-v4-flash" {
-			expected := 1.0 + 1.0 // 1M in × ¥1/M + 0.5M out × ¥2/M
-			if math.Abs(cost.USD-expected) > 0.01 {
+			expected := 0.14 + 0.14 // 1M in × $0.14/M + 0.5M out × $0.28/M
+			if math.Abs(cost.USD-expected) > 0.001 {
 				t.Fatalf("CostFor(%q) = %.4f, want ~%.4f", model, cost.USD, expected)
 			}
 		}
-		// deepseek-v4-pro: ¥3/M in, ¥6/M out
+		// deepseek-v4-pro: $0.435/M in, $0.87/M out
 		if model == "deepseek-v4-pro" {
-			expected := 3.0 + 3.0 // 1M in × ¥3/M + 0.5M out × ¥6/M
-			if math.Abs(cost.USD-expected) > 0.01 {
+			expected := 0.435 + 0.435 // 1M in × $0.435/M + 0.5M out × $0.87/M
+			if math.Abs(cost.USD-expected) > 0.001 {
 				t.Fatalf("CostFor(%q) = %.4f, want ~%.4f", model, cost.USD, expected)
 			}
 		}

--- a/internal/pricing/pricing_test.go
+++ b/internal/pricing/pricing_test.go
@@ -365,23 +365,21 @@ func TestDefaultCatalogCoversDeepSeekModels(t *testing.T) {
 			t.Fatalf("CostFor(%q).Source = unknown (unpriced)", model)
 		}
 		if model == "deepseek-chat" || model == "deepseek-v4-flash" {
-			expectedCNY := 1.0 + 1.0         // 1M in × ¥1/M + 0.5M out × ¥2/M
-			expectedUSD := expectedCNY / 7.2 // ≈ 0.2778
+			expectedCNY := 1.0 + 1.0 // 1M in x ¥1/M + 0.5M out x ¥2/M
 			if math.Abs(cost.Amount-expectedCNY) > 0.01 {
 				t.Fatalf("CostFor(%q).Amount = %.4f, want ~%.4f CNY", model, cost.Amount, expectedCNY)
 			}
-			if math.Abs(cost.USD-expectedUSD) > 0.001 {
-				t.Fatalf("CostFor(%q).USD = %.4f, want ~%.4f", model, cost.USD, expectedUSD)
+			if math.Abs(cost.USD-expectedCNY) > 0.001 {
+				t.Fatalf("CostFor(%q).USD = %.4f, want native %.4f CNY", model, cost.USD, expectedCNY)
 			}
 		}
 		if model == "deepseek-v4-pro" {
-			expectedCNY := 3.0 + 3.0         // 1M in × ¥3/M + 0.5M out × ¥6/M
-			expectedUSD := expectedCNY / 7.2 // ≈ 0.8333
+			expectedCNY := 3.0 + 3.0 // 1M in x ¥3/M + 0.5M out x ¥6/M
 			if math.Abs(cost.Amount-expectedCNY) > 0.01 {
 				t.Fatalf("CostFor(%q).Amount = %.4f, want ~%.4f CNY", model, cost.Amount, expectedCNY)
 			}
-			if math.Abs(cost.USD-expectedUSD) > 0.001 {
-				t.Fatalf("CostFor(%q).USD = %.4f, want ~%.4f", model, cost.USD, expectedUSD)
+			if math.Abs(cost.USD-expectedCNY) > 0.001 {
+				t.Fatalf("CostFor(%q).USD = %.4f, want native %.4f CNY", model, cost.USD, expectedCNY)
 			}
 		}
 	}

--- a/internal/query/query.go
+++ b/internal/query/query.go
@@ -45,6 +45,7 @@ const (
 
 type Cost struct {
 	USD                   float64 `json:"usd"`
+	Currency              string  `json:"currency,omitempty"`
 	Source                string  `json:"source,omitempty"`
 	InputUSDPerMTok       float64 `json:"input_usd_per_mtok,omitempty"`
 	OutputUSDPerMTok      float64 `json:"output_usd_per_mtok,omitempty"`
@@ -55,6 +56,7 @@ type Cost struct {
 
 type Price struct {
 	Source                string  `json:"source"`
+	Currency              string  `json:"currency,omitempty"`
 	InputUSDPerMTok       float64 `json:"input_usd_per_mtok,omitempty"`
 	OutputUSDPerMTok      float64 `json:"output_usd_per_mtok,omitempty"`
 	CacheHitUSDPerMTok    float64 `json:"cache_hit_usd_per_mtok,omitempty"`
@@ -834,7 +836,20 @@ func mergeAggregatedPrice(existing, next *Price) *Price {
 	if len(components) == 1 {
 		return clonePrice(&components[0])
 	}
-	return &Price{Source: "mixed", Components: components}
+	return &Price{Source: "mixed", Currency: commonCurrency(components), Components: components}
+}
+
+func commonCurrency(components []Price) string {
+	if len(components) == 0 {
+		return ""
+	}
+	first := components[0].Currency
+	for _, c := range components[1:] {
+		if c.Currency != first {
+			return ""
+		}
+	}
+	return first
 }
 
 func hasPriceComponents(price *Price) bool {
@@ -876,8 +891,9 @@ func priceComponents(price *Price) []Price {
 }
 
 func priceComponentKey(price Price) string {
-	return fmt.Sprintf("%s|%.12g|%.12g|%.12g|%.12g|%.12g",
+	return fmt.Sprintf("%s|%s|%.12g|%.12g|%.12g|%.12g|%.12g",
 		price.Source,
+		price.Currency,
 		price.InputUSDPerMTok,
 		price.OutputUSDPerMTok,
 		price.CacheHitUSDPerMTok,
@@ -893,6 +909,7 @@ func priceFromCost(cost Cost) *Price {
 	}
 	return &Price{
 		Source:                source,
+		Currency:              cost.Currency,
 		InputUSDPerMTok:       cost.InputUSDPerMTok,
 		OutputUSDPerMTok:      cost.OutputUSDPerMTok,
 		CacheHitUSDPerMTok:    cost.CacheHitUSDPerMTok,
@@ -903,6 +920,7 @@ func priceFromCost(cost Cost) *Price {
 
 func pricesEqual(left, right Price) bool {
 	return left.Source == right.Source &&
+		left.Currency == right.Currency &&
 		left.InputUSDPerMTok == right.InputUSDPerMTok &&
 		left.OutputUSDPerMTok == right.OutputUSDPerMTok &&
 		left.CacheHitUSDPerMTok == right.CacheHitUSDPerMTok &&

--- a/internal/query/query.go
+++ b/internal/query/query.go
@@ -45,6 +45,7 @@ const (
 
 type Cost struct {
 	USD                   float64 `json:"usd"`
+	Amount                float64 `json:"amount,omitempty"`
 	Currency              string  `json:"currency,omitempty"`
 	Source                string  `json:"source,omitempty"`
 	InputUSDPerMTok       float64 `json:"input_usd_per_mtok,omitempty"`

--- a/internal/query/query_test.go
+++ b/internal/query/query_test.go
@@ -63,6 +63,31 @@ func TestAggregateIncludesRequestsAndCost(t *testing.T) {
 	}
 }
 
+func TestAggregateSortsCostByRawAmountAcrossCurrencies(t *testing.T) {
+	loc := time.UTC
+	window := Window{Start: time.Date(2026, 5, 8, 0, 0, 0, 0, loc), End: time.Date(2026, 5, 9, 0, 0, 0, 0, loc)}
+	events := []usage.UsageEvent{
+		{Timestamp: time.Date(2026, 5, 8, 1, 0, 0, 0, loc), Tool: usage.ToolCodex, Model: "usd-model", Provider: "openai", Usage: usage.TokenUsage{Input: 1}},
+		{Timestamp: time.Date(2026, 5, 8, 2, 0, 0, 0, loc), Tool: usage.ToolReasonix, Model: "cny-model", Provider: "deepseek", Usage: usage.TokenUsage{Input: 1}},
+	}
+	acc := NewAccumulatorWithSort(window, Filters{}, GroupBy{"model"}, SortByCost, func(event usage.UsageEvent) Cost {
+		if event.Provider == "deepseek" {
+			return Cost{USD: 2, Currency: "CNY", Source: "default"}
+		}
+		return Cost{USD: 10, Currency: "USD", Source: "default"}
+	})
+	for _, event := range events {
+		acc.Add(event)
+	}
+	results := acc.Results()
+	if len(results) != 2 {
+		t.Fatalf("len(results) = %d, want 2", len(results))
+	}
+	if results[0].Key["model"] != "usd-model" || results[1].Key["model"] != "cny-model" {
+		t.Fatalf("cost sort should use raw amount only, got %+v", results)
+	}
+}
+
 func TestAggregateCarriesPriceDetails(t *testing.T) {
 	loc := time.UTC
 	window := Window{Start: time.Date(2026, 5, 8, 0, 0, 0, 0, loc), End: time.Date(2026, 5, 9, 0, 0, 0, 0, loc)}

--- a/internal/report/governance.go
+++ b/internal/report/governance.go
@@ -32,6 +32,7 @@ type BudgetPayload struct {
 	Window         query.Window   `json:"window"`
 	LimitUSD       float64        `json:"limit_usd"`
 	TotalUSD       float64        `json:"total_usd"`
+	Currency       string         `json:"currency,omitempty"`
 	Exceeded       bool           `json:"exceeded"`
 	UnpricedEvents int            `json:"unpriced_events"`
 	UnpricedTokens int64          `json:"unpriced_tokens"`
@@ -128,9 +129,10 @@ func WritePricingAudit(w io.Writer, format string, payload PricingAuditPayload) 
 }
 
 func WriteBudget(w io.Writer, format string, payload BudgetPayload) error {
+	limitLabel := budgetCurrencyLabel(payload.Currency)
 	switch format {
 	case "", "table":
-		if _, err := fmt.Fprintf(w, "Limit USD: %s\nTotal USD: %s\nExceeded: %t\nUnpriced events: %d\n\n", FormatUSD(payload.LimitUSD), FormatUSD(payload.TotalUSD), payload.Exceeded, payload.UnpricedEvents); err != nil {
+		if _, err := fmt.Fprintf(w, "Limit %s: %s\nTotal %s: %s\nExceeded: %t\nUnpriced events: %d\n\n", limitLabel, FormatCost(payload.LimitUSD, payload.Currency), limitLabel, FormatCost(payload.TotalUSD, payload.Currency), payload.Exceeded, payload.UnpricedEvents); err != nil {
 			return err
 		}
 		return WriteTable(w, payload.Results)
@@ -139,18 +141,27 @@ func WriteBudget(w io.Writer, format string, payload BudgetPayload) error {
 		encoder.SetIndent("", "  ")
 		return encoder.Encode(payload)
 	case "markdown":
-		if _, err := fmt.Fprintf(w, "| Limit USD | Total USD | Exceeded | Unpriced Events |\n"); err != nil {
+		if _, err := fmt.Fprintf(w, "| Limit %s | Total %s | Exceeded | Unpriced Events |\n", limitLabel, limitLabel); err != nil {
 			return err
 		}
 		if _, err := fmt.Fprintf(w, "| ---: | ---: | --- | ---: |\n"); err != nil {
 			return err
 		}
-		if _, err := fmt.Fprintf(w, "| %s | %s | %t | %d |\n\n", FormatUSD(payload.LimitUSD), FormatUSD(payload.TotalUSD), payload.Exceeded, payload.UnpricedEvents); err != nil {
+		if _, err := fmt.Fprintf(w, "| %s | %s | %t | %d |\n\n", FormatCost(payload.LimitUSD, payload.Currency), FormatCost(payload.TotalUSD, payload.Currency), payload.Exceeded, payload.UnpricedEvents); err != nil {
 			return err
 		}
 		return WriteMarkdown(w, payload.Results)
 	default:
 		return fmt.Errorf("unknown format %q", format)
+	}
+}
+
+func budgetCurrencyLabel(currency string) string {
+	switch strings.ToUpper(currency) {
+	case "CNY", "RMB":
+		return "CNY"
+	default:
+		return "USD"
 	}
 }
 

--- a/internal/report/governance.go
+++ b/internal/report/governance.go
@@ -32,7 +32,8 @@ type BudgetPayload struct {
 	Window         query.Window   `json:"window"`
 	LimitUSD       float64        `json:"limit_usd"`
 	TotalUSD       float64        `json:"total_usd"`
-	Currency       string         `json:"currency,omitempty"`
+	NonUSDTotal    float64        `json:"non_usd_total,omitempty"`
+	NonUSDCurrency string         `json:"non_usd_currency,omitempty"`
 	Exceeded       bool           `json:"exceeded"`
 	UnpricedEvents int            `json:"unpriced_events"`
 	UnpricedTokens int64          `json:"unpriced_tokens"`
@@ -129,10 +130,17 @@ func WritePricingAudit(w io.Writer, format string, payload PricingAuditPayload) 
 }
 
 func WriteBudget(w io.Writer, format string, payload BudgetPayload) error {
-	limitLabel := budgetCurrencyLabel(payload.Currency)
 	switch format {
 	case "", "table":
-		if _, err := fmt.Fprintf(w, "Limit %s: %s\nTotal %s: %s\nExceeded: %t\nUnpriced events: %d\n\n", limitLabel, FormatCost(payload.LimitUSD, payload.Currency), limitLabel, FormatCost(payload.TotalUSD, payload.Currency), payload.Exceeded, payload.UnpricedEvents); err != nil {
+		if _, err := fmt.Fprintf(w, "Limit USD: %s\nTotal USD: %s\nExceeded: %t\nUnpriced events: %d\n", FormatUSD(payload.LimitUSD), FormatUSD(payload.TotalUSD), payload.Exceeded, payload.UnpricedEvents); err != nil {
+			return err
+		}
+		if payload.NonUSDTotal > 0 {
+			if _, err := fmt.Fprintf(w, "Non-USD total (%s): %s (excluded from budget check)\n", payload.NonUSDCurrency, FormatCost(payload.NonUSDTotal, payload.NonUSDCurrency)); err != nil {
+				return err
+			}
+		}
+		if _, err := fmt.Fprintln(w); err != nil {
 			return err
 		}
 		return WriteTable(w, payload.Results)
@@ -141,27 +149,23 @@ func WriteBudget(w io.Writer, format string, payload BudgetPayload) error {
 		encoder.SetIndent("", "  ")
 		return encoder.Encode(payload)
 	case "markdown":
-		if _, err := fmt.Fprintf(w, "| Limit %s | Total %s | Exceeded | Unpriced Events |\n", limitLabel, limitLabel); err != nil {
+		if _, err := fmt.Fprintf(w, "| Limit USD | Total USD | Exceeded | Unpriced Events |\n"); err != nil {
 			return err
 		}
 		if _, err := fmt.Fprintf(w, "| ---: | ---: | --- | ---: |\n"); err != nil {
 			return err
 		}
-		if _, err := fmt.Fprintf(w, "| %s | %s | %t | %d |\n\n", FormatCost(payload.LimitUSD, payload.Currency), FormatCost(payload.TotalUSD, payload.Currency), payload.Exceeded, payload.UnpricedEvents); err != nil {
+		if _, err := fmt.Fprintf(w, "| %s | %s | %t | %d |\n", FormatUSD(payload.LimitUSD), FormatUSD(payload.TotalUSD), payload.Exceeded, payload.UnpricedEvents); err != nil {
 			return err
+		}
+		if payload.NonUSDTotal > 0 {
+			if _, err := fmt.Fprintf(w, "\nNon-USD total (%s): %s (excluded from budget check)\n", payload.NonUSDCurrency, FormatCost(payload.NonUSDTotal, payload.NonUSDCurrency)); err != nil {
+				return err
+			}
 		}
 		return WriteMarkdown(w, payload.Results)
 	default:
 		return fmt.Errorf("unknown format %q", format)
-	}
-}
-
-func budgetCurrencyLabel(currency string) string {
-	switch strings.ToUpper(currency) {
-	case "CNY", "RMB":
-		return "CNY"
-	default:
-		return "USD"
 	}
 }
 

--- a/internal/report/report.go
+++ b/internal/report/report.go
@@ -310,6 +310,15 @@ func WriteThreadsMarkdown(w io.Writer, threads []query.ThreadResult, opts ...Opt
 	return nil
 }
 
+func displayAmount(usdValue float64, currency string) float64 {
+	switch strings.ToUpper(currency) {
+	case "CNY", "RMB":
+		return usdValue * 7.2
+	default:
+		return usdValue
+	}
+}
+
 func currencySymbol(currency string) string {
 	switch strings.ToUpper(currency) {
 	case "CNY", "RMB":
@@ -324,7 +333,7 @@ func FormatUSD(value float64) string {
 }
 
 func FormatCost(value float64, currency string) string {
-	return fmt.Sprintf("%s%.4f", currencySymbol(currency), value)
+	return fmt.Sprintf("%s%.4f", currencySymbol(currency), displayAmount(value, currency))
 }
 
 func FormatThreadCost(thread query.ThreadResult) string {

--- a/internal/report/report.go
+++ b/internal/report/report.go
@@ -221,7 +221,7 @@ func WriteMarkdown(w io.Writer, results []query.Result, opts ...Options) error {
 				escapeMarkdown(formatKey(result.Key)),
 				result.Requests,
 				result.Events,
-				FormatUSD(result.CostUSD),
+				FormatCost(result.CostUSD, resultCurrency(result)),
 				escapeMarkdown(formatPrice(result.Price, result.PriceSource)),
 				result.Usage.Input,
 				result.Usage.Output,
@@ -246,7 +246,7 @@ func WriteMarkdown(w io.Writer, results []query.Result, opts ...Options) error {
 		if _, err := fmt.Fprintf(w, "| %s | %d | %s | %s | %d |\n",
 			escapeMarkdown(formatKey(result.Key)),
 			result.Requests,
-			FormatUSD(result.CostUSD),
+			FormatCost(result.CostUSD, resultCurrency(result)),
 			escapeMarkdown(formatPrice(result.Price, result.PriceSource)),
 			result.Usage.NormalizedTotal(),
 		); err != nil {

--- a/internal/report/report.go
+++ b/internal/report/report.go
@@ -310,15 +310,6 @@ func WriteThreadsMarkdown(w io.Writer, threads []query.ThreadResult, opts ...Opt
 	return nil
 }
 
-func displayAmount(usdValue float64, currency string) float64 {
-	switch strings.ToUpper(currency) {
-	case "CNY", "RMB":
-		return usdValue * 7.2
-	default:
-		return usdValue
-	}
-}
-
 func currencySymbol(currency string) string {
 	switch strings.ToUpper(currency) {
 	case "CNY", "RMB":
@@ -333,7 +324,7 @@ func FormatUSD(value float64) string {
 }
 
 func FormatCost(value float64, currency string) string {
-	return fmt.Sprintf("%s%.4f", currencySymbol(currency), displayAmount(value, currency))
+	return fmt.Sprintf("%s%.4f", currencySymbol(currency), value)
 }
 
 func FormatThreadCost(thread query.ThreadResult) string {

--- a/internal/report/report.go
+++ b/internal/report/report.go
@@ -70,9 +70,9 @@ func WriteThreadsTable(w io.Writer, threads []query.ThreadResult, opts ...Option
 	if len(opts) > 0 {
 		option = opts[0]
 	}
-	headers := []string{"ID", "NAME", "TOOL", "MODEL", "PROVIDER", "REQ", "COST_USD", "PRICE", "TOTAL"}
+	headers := []string{"ID", "NAME", "TOOL", "MODEL", "PROVIDER", "REQ", "COST", "PRICE", "TOTAL"}
 	if option.Full {
-		headers = []string{"ID", "NAME", "TOOL", "MODEL", "PROVIDER", "REQ", "EVENTS", "COST_USD", "PRICE", "TOTAL"}
+		headers = []string{"ID", "NAME", "TOOL", "MODEL", "PROVIDER", "REQ", "EVENTS", "COST", "PRICE", "TOTAL"}
 	}
 	rows := make([][]string, 0, len(threads))
 	for _, thread := range threads {
@@ -111,16 +111,16 @@ func WriteTable(w io.Writer, results []query.Result, opts ...Options) error {
 	if len(opts) > 0 {
 		option = opts[0]
 	}
-	headers := []string{"GROUP", "REQ", "COST_USD", "PRICE", "TOTAL"}
+	headers := []string{"GROUP", "REQ", "COST", "PRICE", "TOTAL"}
 	if option.Full {
-		headers = []string{"GROUP", "REQ", "EVENTS", "COST_USD", "PRICE", "INPUT", "OUTPUT", "CACHED", "CACHE_CREATE", "REASONING", "TOOL", "TOTAL"}
+		headers = []string{"GROUP", "REQ", "EVENTS", "COST", "PRICE", "INPUT", "OUTPUT", "CACHED", "CACHE_CREATE", "REASONING", "TOOL", "TOTAL"}
 	}
 	rows := make([][]string, 0, len(results))
 	for _, result := range results {
 		row := []string{
 			formatKey(result.Key),
 			fmt.Sprint(result.Requests),
-			FormatUSD(result.CostUSD),
+			FormatCost(result.CostUSD, resultCurrency(result)),
 			formatPrice(result.Price, result.PriceSource),
 			fmt.Sprint(result.Usage.NormalizedTotal()),
 		}
@@ -129,7 +129,7 @@ func WriteTable(w io.Writer, results []query.Result, opts ...Options) error {
 				formatKey(result.Key),
 				fmt.Sprint(result.Requests),
 				fmt.Sprint(result.Events),
-				FormatUSD(result.CostUSD),
+				FormatCost(result.CostUSD, resultCurrency(result)),
 				formatPrice(result.Price, result.PriceSource),
 				fmt.Sprint(result.Usage.Input),
 				fmt.Sprint(result.Usage.Output),
@@ -210,7 +210,7 @@ func WriteMarkdown(w io.Writer, results []query.Result, opts ...Options) error {
 		option = opts[0]
 	}
 	if option.Full {
-		if _, err := fmt.Fprintln(w, "| Group | Req | Events | Cost USD | Price | Input | Output | Cached | Cache Create | Reasoning | Tool | Total |"); err != nil {
+		if _, err := fmt.Fprintln(w, "| Group | Req | Events | Cost | Price | Input | Output | Cached | Cache Create | Reasoning | Tool | Total |"); err != nil {
 			return err
 		}
 		if _, err := fmt.Fprintln(w, "| --- | ---: | ---: | ---: | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |"); err != nil {
@@ -236,7 +236,7 @@ func WriteMarkdown(w io.Writer, results []query.Result, opts ...Options) error {
 		}
 		return nil
 	}
-	if _, err := fmt.Fprintln(w, "| Group | Req | Cost USD | Price | Total |"); err != nil {
+	if _, err := fmt.Fprintln(w, "| Group | Req | Cost | Price | Total |"); err != nil {
 		return err
 	}
 	if _, err := fmt.Fprintln(w, "| --- | ---: | ---: | --- | ---: |"); err != nil {
@@ -262,7 +262,7 @@ func WriteThreadsMarkdown(w io.Writer, threads []query.ThreadResult, opts ...Opt
 		option = opts[0]
 	}
 	if option.Full {
-		if _, err := fmt.Fprintln(w, "| ID | Name | Tool | Model | Provider | Req | Events | Cost USD | Price | Total |"); err != nil {
+		if _, err := fmt.Fprintln(w, "| ID | Name | Tool | Model | Provider | Req | Events | Cost | Price | Total |"); err != nil {
 			return err
 		}
 		if _, err := fmt.Fprintln(w, "| --- | --- | --- | --- | --- | ---: | ---: | ---: | --- | ---: |"); err != nil {
@@ -286,7 +286,7 @@ func WriteThreadsMarkdown(w io.Writer, threads []query.ThreadResult, opts ...Opt
 		}
 		return nil
 	}
-	if _, err := fmt.Fprintln(w, "| ID | Name | Tool | Model | Provider | Req | Cost USD | Price | Total |"); err != nil {
+	if _, err := fmt.Fprintln(w, "| ID | Name | Tool | Model | Provider | Req | Cost | Price | Total |"); err != nil {
 		return err
 	}
 	if _, err := fmt.Fprintln(w, "| --- | --- | --- | --- | --- | ---: | ---: | --- | ---: |"); err != nil {
@@ -310,30 +310,74 @@ func WriteThreadsMarkdown(w io.Writer, threads []query.ThreadResult, opts ...Opt
 	return nil
 }
 
+func currencySymbol(currency string) string {
+	switch strings.ToUpper(currency) {
+	case "CNY", "RMB":
+		return "¥"
+	default:
+		return "$"
+	}
+}
+
 func FormatUSD(value float64) string {
-	return fmt.Sprintf("$%.4f", value)
+	return FormatCost(value, "")
+}
+
+func FormatCost(value float64, currency string) string {
+	return fmt.Sprintf("%s%.4f", currencySymbol(currency), value)
 }
 
 func FormatThreadCost(thread query.ThreadResult) string {
-	total := FormatUSD(thread.CostUSD)
+	currency := threadCurrency(thread)
+	total := FormatCost(thread.CostUSD, currency)
 	if len(thread.CostBreakdown) == 0 {
 		return total
 	}
 	parts := make([]string, 0, len(thread.CostBreakdown))
 	for _, item := range thread.CostBreakdown {
-		parts = append(parts, item.Provider+" "+FormatUSD(item.USD))
+		parts = append(parts, item.Provider+" "+FormatCost(item.USD, currency))
 	}
 	return total + " (" + strings.Join(parts, ", ") + ")"
+}
+
+func threadCurrency(thread query.ThreadResult) string {
+	if thread.Price != nil && thread.Price.Currency != "" {
+		return thread.Price.Currency
+	}
+	return "USD"
+}
+
+func resultCurrency(result query.Result) string {
+	if result.Price != nil && result.Price.Currency != "" {
+		return result.Price.Currency
+	}
+	return "USD"
 }
 
 func formatPrice(price *query.Price, source string) string {
 	return FormatPrice(price, source)
 }
 
+func priceCurrency(price *query.Price) string {
+	if price == nil {
+		return "USD"
+	}
+	if price.Currency != "" {
+		return price.Currency
+	}
+	if price.Source == "mixed" && len(price.Components) > 0 {
+		if cur := price.Components[0].Currency; cur != "" {
+			return cur
+		}
+	}
+	return "USD"
+}
+
 func FormatPrice(price *query.Price, source string) string {
 	if price == nil {
 		return displayPriceSource(source)
 	}
+	cur := priceCurrency(price)
 	if price.Source == "mixed" {
 		return formatMixedPrice(price, source)
 	}
@@ -342,10 +386,10 @@ func FormatPrice(price *query.Price, source string) string {
 	}
 	return fmt.Sprintf("%s in=%s out=%s cache=%s make=%s",
 		displayPriceSource(price.Source),
-		formatRate(price.InputUSDPerMTok),
-		formatRate(price.OutputUSDPerMTok),
-		formatRate(price.CacheHitUSDPerMTok),
-		formatRate(price.CacheMakeUSDPerMTok),
+		formatRateWithCurrency(price.InputUSDPerMTok, cur),
+		formatRateWithCurrency(price.OutputUSDPerMTok, cur),
+		formatRateWithCurrency(price.CacheHitUSDPerMTok, cur),
+		formatRateWithCurrency(price.CacheMakeUSDPerMTok, cur),
 	)
 }
 
@@ -353,6 +397,7 @@ func FormatPriceCompact(price *query.Price, source string) string {
 	if price == nil {
 		return displayPriceSource(source)
 	}
+	cur := priceCurrency(price)
 	if price.Source == "mixed" {
 		return formatMixedPriceCompact(price, source)
 	}
@@ -361,34 +406,36 @@ func FormatPriceCompact(price *query.Price, source string) string {
 	}
 	return fmt.Sprintf("%s in=%s out=%s",
 		displayPriceSource(price.Source),
-		formatRate(price.InputUSDPerMTok),
-		formatRate(price.OutputUSDPerMTok),
+		formatRateWithCurrency(price.InputUSDPerMTok, cur),
+		formatRateWithCurrency(price.OutputUSDPerMTok, cur),
 	)
 }
 
 func formatMixedPrice(price *query.Price, source string) string {
+	cur := priceCurrency(price)
 	if len(price.Components) == 0 {
 		return displayPriceSource(coalescePriceSource(price.Source, source))
 	}
 	return fmt.Sprintf("%s %s in=%s out=%s cache=%s make=%s",
 		displayPriceSource(price.Source),
 		mixedPriceSources(price.Components),
-		formatRateRange(price.Components, func(component query.Price) float64 { return component.InputUSDPerMTok }),
-		formatRateRange(price.Components, func(component query.Price) float64 { return component.OutputUSDPerMTok }),
-		formatRateRange(price.Components, func(component query.Price) float64 { return component.CacheHitUSDPerMTok }),
-		formatRateRange(price.Components, func(component query.Price) float64 { return component.CacheMakeUSDPerMTok }),
+		formatRateRange(price.Components, cur, func(component query.Price) float64 { return component.InputUSDPerMTok }),
+		formatRateRange(price.Components, cur, func(component query.Price) float64 { return component.OutputUSDPerMTok }),
+		formatRateRange(price.Components, cur, func(component query.Price) float64 { return component.CacheHitUSDPerMTok }),
+		formatRateRange(price.Components, cur, func(component query.Price) float64 { return component.CacheMakeUSDPerMTok }),
 	)
 }
 
 func formatMixedPriceCompact(price *query.Price, source string) string {
+	cur := priceCurrency(price)
 	if len(price.Components) == 0 {
 		return displayPriceSource(coalescePriceSource(price.Source, source))
 	}
 	return fmt.Sprintf("%s %s %s/%s",
 		displayPriceSource(price.Source),
 		mixedPriceSources(price.Components),
-		formatRateValueRange(price.Components, func(component query.Price) float64 { return component.InputUSDPerMTok }),
-		strings.TrimPrefix(formatRateRange(price.Components, func(component query.Price) float64 { return component.OutputUSDPerMTok }), "$"),
+		formatRateValueRange(price.Components, cur, func(component query.Price) float64 { return component.InputUSDPerMTok }),
+		strings.TrimPrefix(formatRateRange(price.Components, cur, func(component query.Price) float64 { return component.OutputUSDPerMTok }), currencySymbol(cur)),
 	)
 }
 
@@ -407,13 +454,13 @@ func mixedPriceSources(components []query.Price) string {
 	return strings.Join(sources, "+")
 }
 
-func formatRateRange(components []query.Price, valueFor func(query.Price) float64) string {
-	return formatRateValueRange(components, valueFor) + "/M"
+func formatRateRange(components []query.Price, currency string, valueFor func(query.Price) float64) string {
+	return formatRateValueRange(components, currency, valueFor) + "/M"
 }
 
-func formatRateValueRange(components []query.Price, valueFor func(query.Price) float64) string {
+func formatRateValueRange(components []query.Price, currency string, valueFor func(query.Price) float64) string {
 	if len(components) == 0 {
-		return formatRateValue(0)
+		return formatRateValueWithCurrency(0, currency)
 	}
 	var minValue, maxValue float64
 	hasValue := false
@@ -428,9 +475,10 @@ func formatRateValueRange(components []query.Price, valueFor func(query.Price) f
 		hasValue = true
 	}
 	if minValue == maxValue {
-		return formatRateValue(minValue)
+		return formatRateValueWithCurrency(minValue, currency)
 	}
-	return fmt.Sprintf("%s..%s", formatRateValue(minValue), strings.TrimPrefix(formatRateValue(maxValue), "$"))
+	sym := currencySymbol(currency)
+	return fmt.Sprintf("%s..%s", formatRateValueWithCurrency(minValue, currency), strings.TrimPrefix(formatRateValueWithCurrency(maxValue, currency), sym))
 }
 
 func coalescePriceSource(primary, fallback string) string {
@@ -448,11 +496,19 @@ func displayPriceSource(source string) string {
 }
 
 func formatRate(value float64) string {
-	return formatRateValue(value) + "/M"
+	return formatRateWithCurrency(value, "") + "/M"
+}
+
+func formatRateWithCurrency(value float64, currency string) string {
+	return formatRateValueWithCurrency(value, currency) + "/M"
 }
 
 func formatRateValue(value float64) string {
-	return fmt.Sprintf("$%.4g", value)
+	return formatRateValueWithCurrency(value, "")
+}
+
+func formatRateValueWithCurrency(value float64, currency string) string {
+	return fmt.Sprintf("%s%.4g", currencySymbol(currency), value)
 }
 
 func formatKey(key map[string]string) string {

--- a/internal/report/report_test.go
+++ b/internal/report/report_test.go
@@ -40,54 +40,6 @@ func TestWriteJSONAndMarkdown(t *testing.T) {
 	}
 }
 
-func TestWriteMarkdownDisplaysCNYForDeepSeek(t *testing.T) {
-	payload := Payload{
-		GeneratedAt: time.Date(2026, 5, 8, 0, 0, 0, 0, time.UTC),
-		Results: []query.Result{{
-			Key:      map[string]string{"tool": "reasonix", "model": "deepseek-v4-flash"},
-			Requests: 1,
-			Usage:    usage.TokenUsage{Input: 100, Output: 50},
-			CostUSD:  0.0002,
-			Price:    &query.Price{Source: "default", Currency: "CNY", InputUSDPerMTok: 1, OutputUSDPerMTok: 2},
-		}},
-	}
-	var mdOut bytes.Buffer
-	if err := Write(&mdOut, "markdown", payload); err != nil {
-		t.Fatal(err)
-	}
-	got := mdOut.String()
-	if strings.Contains(got, "$0.0002") {
-		t.Fatalf("CNY markdown should NOT show $: %s", got)
-	}
-	if !strings.Contains(got, "¥0.0002") {
-		t.Fatalf("CNY markdown missing ¥: %s", got)
-	}
-}
-
-func TestWriteTableDisplaysCNYForDeepSeek(t *testing.T) {
-	var out bytes.Buffer
-	err := WriteTable(&out, []query.Result{{
-		Key:      map[string]string{"tool": "reasonix", "model": "deepseek-v4-flash"},
-		Requests: 1,
-		Usage:    usage.TokenUsage{Input: 100, Output: 50},
-		CostUSD:  0.0002,
-		Price:    &query.Price{Source: "default", Currency: "CNY", InputUSDPerMTok: 1, OutputUSDPerMTok: 2},
-	}})
-	if err != nil {
-		t.Fatal(err)
-	}
-	got := out.String()
-	if strings.Contains(got, "$0.0002") {
-		t.Fatalf("CNY price should NOT show $ prefix: %s", got)
-	}
-	if !strings.Contains(got, "¥0.0002") {
-		t.Fatalf("CNY price missing ¥ prefix: %s", got)
-	}
-	if !strings.Contains(got, "¥1/M") || !strings.Contains(got, "¥2/M") {
-		t.Fatalf("CNY rate missing ¥ prefix: %s", got)
-	}
-}
-
 func TestWriteTableDisplaysCustomAndOfficialPriceRates(t *testing.T) {
 	var out bytes.Buffer
 	err := WriteTable(&out, []query.Result{

--- a/internal/report/report_test.go
+++ b/internal/report/report_test.go
@@ -46,7 +46,7 @@ func TestWriteTableDisplaysCNYForDeepSeek(t *testing.T) {
 		Key:      map[string]string{"tool": "reasonix", "model": "deepseek-v4-flash"},
 		Requests: 1,
 		Usage:    usage.TokenUsage{Input: 1_000_000, Output: 500_000},
-		CostUSD:  0.2777777,
+		CostUSD:  2,
 		Price:    &query.Price{Source: "default", Currency: "CNY", InputUSDPerMTok: 1, OutputUSDPerMTok: 2},
 	}})
 	if err != nil {
@@ -56,7 +56,7 @@ func TestWriteTableDisplaysCNYForDeepSeek(t *testing.T) {
 	if !strings.Contains(got, "¥2.0000") {
 		t.Fatalf("CNY cost should show ¥2.0000: %s", got)
 	}
-	if strings.Contains(got, "$0.2778") {
+	if strings.Contains(got, "$2.0000") {
 		t.Fatalf("CNY cost should NOT show $: %s", got)
 	}
 }

--- a/internal/report/report_test.go
+++ b/internal/report/report_test.go
@@ -35,8 +35,32 @@ func TestWriteJSONAndMarkdown(t *testing.T) {
 	if err := Write(&mdOut, "markdown", payload); err != nil {
 		t.Fatal(err)
 	}
-	if !strings.Contains(mdOut.String(), "| Group | Req | Cost USD | Price | Total |") || !strings.Contains(mdOut.String(), "| tool=codex | 1 | $0.0123 | official in=$2.5/M out=$15/M cache=$0.25/M make=$2.5/M | 12 |") {
+	if !strings.Contains(mdOut.String(), "| Group | Req | Cost | Price | Total |") || !strings.Contains(mdOut.String(), "| tool=codex | 1 | $0.0123 | official in=$2.5/M out=$15/M cache=$0.25/M make=$2.5/M | 12 |") {
 		t.Fatalf("markdown output unexpected: %s", mdOut.String())
+	}
+}
+
+func TestWriteTableDisplaysCNYForDeepSeek(t *testing.T) {
+	var out bytes.Buffer
+	err := WriteTable(&out, []query.Result{{
+		Key:      map[string]string{"tool": "reasonix", "model": "deepseek-v4-flash"},
+		Requests: 1,
+		Usage:    usage.TokenUsage{Input: 100, Output: 50},
+		CostUSD:  0.0002,
+		Price:    &query.Price{Source: "default", Currency: "CNY", InputUSDPerMTok: 1, OutputUSDPerMTok: 2},
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := out.String()
+	if strings.Contains(got, "$0.0002") {
+		t.Fatalf("CNY price should NOT show $ prefix: %s", got)
+	}
+	if !strings.Contains(got, "¥0.0002") {
+		t.Fatalf("CNY price missing ¥ prefix: %s", got)
+	}
+	if !strings.Contains(got, "¥1/M") || !strings.Contains(got, "¥2/M") {
+		t.Fatalf("CNY rate missing ¥ prefix: %s", got)
 	}
 }
 
@@ -104,7 +128,7 @@ func TestWriteTableUsesCompactDefaultColumns(t *testing.T) {
 		t.Fatal(err)
 	}
 	got := out.String()
-	if !strings.Contains(got, "REQ") || !strings.Contains(got, "COST_USD") || !strings.Contains(got, "PRICE") || !strings.Contains(got, "$1.2345") {
+	if !strings.Contains(got, "REQ") || !strings.Contains(got, "COST") || !strings.Contains(got, "PRICE") || !strings.Contains(got, "$1.2345") {
 		t.Fatalf("table missing request/cost fields: %s", got)
 	}
 	if strings.Contains(got, "EVENTS") || strings.Contains(got, "CACHE_CREATE") {

--- a/internal/report/report_test.go
+++ b/internal/report/report_test.go
@@ -40,6 +40,30 @@ func TestWriteJSONAndMarkdown(t *testing.T) {
 	}
 }
 
+func TestWriteMarkdownDisplaysCNYForDeepSeek(t *testing.T) {
+	payload := Payload{
+		GeneratedAt: time.Date(2026, 5, 8, 0, 0, 0, 0, time.UTC),
+		Results: []query.Result{{
+			Key:      map[string]string{"tool": "reasonix", "model": "deepseek-v4-flash"},
+			Requests: 1,
+			Usage:    usage.TokenUsage{Input: 100, Output: 50},
+			CostUSD:  0.0002,
+			Price:    &query.Price{Source: "default", Currency: "CNY", InputUSDPerMTok: 1, OutputUSDPerMTok: 2},
+		}},
+	}
+	var mdOut bytes.Buffer
+	if err := Write(&mdOut, "markdown", payload); err != nil {
+		t.Fatal(err)
+	}
+	got := mdOut.String()
+	if strings.Contains(got, "$0.0002") {
+		t.Fatalf("CNY markdown should NOT show $: %s", got)
+	}
+	if !strings.Contains(got, "¥0.0002") {
+		t.Fatalf("CNY markdown missing ¥: %s", got)
+	}
+}
+
 func TestWriteTableDisplaysCNYForDeepSeek(t *testing.T) {
 	var out bytes.Buffer
 	err := WriteTable(&out, []query.Result{{

--- a/internal/report/report_test.go
+++ b/internal/report/report_test.go
@@ -40,6 +40,27 @@ func TestWriteJSONAndMarkdown(t *testing.T) {
 	}
 }
 
+func TestWriteTableDisplaysCNYForDeepSeek(t *testing.T) {
+	var out bytes.Buffer
+	err := WriteTable(&out, []query.Result{{
+		Key:      map[string]string{"tool": "reasonix", "model": "deepseek-v4-flash"},
+		Requests: 1,
+		Usage:    usage.TokenUsage{Input: 1_000_000, Output: 500_000},
+		CostUSD:  0.2777777,
+		Price:    &query.Price{Source: "default", Currency: "CNY", InputUSDPerMTok: 1, OutputUSDPerMTok: 2},
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := out.String()
+	if !strings.Contains(got, "¥2.0000") {
+		t.Fatalf("CNY cost should show ¥2.0000: %s", got)
+	}
+	if strings.Contains(got, "$0.2778") {
+		t.Fatalf("CNY cost should NOT show $: %s", got)
+	}
+}
+
 func TestWriteTableDisplaysCustomAndOfficialPriceRates(t *testing.T) {
 	var out bytes.Buffer
 	err := WriteTable(&out, []query.Result{

--- a/internal/sources/collect.go
+++ b/internal/sources/collect.go
@@ -13,6 +13,7 @@ func Defaults(opts Options) []Source {
 		NewClaude(opts),
 		NewCodex(opts),
 		NewGemini(opts),
+		NewReasonix(opts),
 	}
 }
 

--- a/internal/sources/reasonix.go
+++ b/internal/sources/reasonix.go
@@ -18,17 +18,17 @@ type Reasonix struct {
 }
 
 type reasonixUsageRecord struct {
-	Ts               int64              `json:"ts"`
-	Session          *string            `json:"session"`
-	Model            string             `json:"model"`
-	PromptTokens     int64              `json:"promptTokens"`
-	CompletionTokens int64              `json:"completionTokens"`
-	CacheHitTokens   int64              `json:"cacheHitTokens"`
-	CacheMissTokens  int64              `json:"cacheMissTokens"`
-	CostUsd          float64            `json:"costUsd"`
-	ClaudeEquivUsd   float64            `json:"claudeEquivUsd"`
-	Kind             string             `json:"kind,omitempty"`
-	Subagent         *reasonixSubagent  `json:"subagent,omitempty"`
+	Ts               int64             `json:"ts"`
+	Session          *string           `json:"session"`
+	Model            string            `json:"model"`
+	PromptTokens     int64             `json:"promptTokens"`
+	CompletionTokens int64             `json:"completionTokens"`
+	CacheHitTokens   int64             `json:"cacheHitTokens"`
+	CacheMissTokens  int64             `json:"cacheMissTokens"`
+	CostUsd          float64           `json:"costUsd"`
+	ClaudeEquivUsd   float64           `json:"claudeEquivUsd"`
+	Kind             string            `json:"kind,omitempty"`
+	Subagent         *reasonixSubagent `json:"subagent,omitempty"`
 }
 
 type reasonixSubagent struct {
@@ -270,7 +270,7 @@ func reasonixEventID(ts time.Time, model string, tokens usage.TokenUsage) string
 }
 
 func reasonixUUID(tsMicro int64, model string, tokens usage.TokenUsage) string {
-	h := tsMicro ^ int64(tokens.Input)^int64(tokens.Output)^int64(tokens.CachedInput)^int64(tokens.CacheCreation)
+	h := tsMicro ^ int64(tokens.Input) ^ int64(tokens.Output) ^ int64(tokens.CachedInput) ^ int64(tokens.CacheCreation)
 	return usage.Unknown(model) + "-" + formatInt64(h)
 }
 
@@ -308,5 +308,3 @@ func formatInt64(n int64) string {
 	}
 	return string(buf[i:])
 }
-
-

--- a/internal/sources/reasonix.go
+++ b/internal/sources/reasonix.go
@@ -1,0 +1,312 @@
+package sources
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/MagnumGoYB/aitok/internal/usage"
+)
+
+type Reasonix struct {
+	Home        string
+	WindowStart time.Time
+	WindowEnd   time.Time
+}
+
+type reasonixUsageRecord struct {
+	Ts               int64              `json:"ts"`
+	Session          *string            `json:"session"`
+	Model            string             `json:"model"`
+	PromptTokens     int64              `json:"promptTokens"`
+	CompletionTokens int64              `json:"completionTokens"`
+	CacheHitTokens   int64              `json:"cacheHitTokens"`
+	CacheMissTokens  int64              `json:"cacheMissTokens"`
+	CostUsd          float64            `json:"costUsd"`
+	ClaudeEquivUsd   float64            `json:"claudeEquivUsd"`
+	Kind             string             `json:"kind,omitempty"`
+	Subagent         *reasonixSubagent  `json:"subagent,omitempty"`
+}
+
+type reasonixSubagent struct {
+	SkillName   string `json:"skillName,omitempty"`
+	TaskPreview string `json:"taskPreview"`
+	ToolIters   int64  `json:"toolIters"`
+	DurationMs  int64  `json:"durationMs"`
+}
+
+func NewReasonix(opts Options) Reasonix {
+	return Reasonix{
+		Home:        cleanHome(opts.Home),
+		WindowStart: opts.WindowStart,
+		WindowEnd:   opts.WindowEnd,
+	}
+}
+
+func (r Reasonix) Name() usage.Tool {
+	return usage.ToolReasonix
+}
+
+func (r Reasonix) Read(ctx context.Context) ([]usage.UsageEvent, error) {
+	var events []usage.UsageEvent
+	err := r.Scan(ctx, func(event usage.UsageEvent) error {
+		events = append(events, event)
+		return nil
+	})
+	return events, err
+}
+
+func (r Reasonix) Scan(ctx context.Context, handle func(usage.UsageEvent) error) error {
+	sessions := r.sessionMetaByID()
+	usageLog := filepath.Join(r.Home, ".reasonix", "usage.jsonl")
+	err := readJSONLines(ctx, usageLog, func(obj map[string]any) error {
+		event, ok := r.parseEvent(obj)
+		if !ok {
+			return nil
+		}
+		if meta, found := sessions[event.ThreadID]; found {
+			event.ThreadName = meta.Name
+			event.ThreadSource = meta.Source
+			event.ThreadCreatedAt = meta.CreatedAt
+			event.ThreadLastActiveAt = meta.LastActiveAt
+		}
+		if !r.WindowStart.IsZero() && event.Timestamp.Before(r.WindowStart) {
+			return nil
+		}
+		if !r.WindowEnd.IsZero() && !event.Timestamp.Before(r.WindowEnd) {
+			return nil
+		}
+		return handle(event)
+	})
+	if os.IsNotExist(err) {
+		return nil
+	}
+	return err
+}
+
+func (r Reasonix) sessionMetaByID() map[string]threadMeta {
+	out := map[string]threadMeta{}
+	sessionsDir := filepath.Join(r.Home, ".reasonix", "sessions")
+	entries, err := os.ReadDir(sessionsDir)
+	if err != nil {
+		return out
+	}
+	for _, entry := range entries {
+		name := entry.Name()
+		// Directory format: sessions/<name>/.meta.json
+		if entry.IsDir() {
+			meta := r.parseSessionMeta(sessionsDir, name)
+			out[name] = *meta
+			continue
+		}
+		// Flat format: sessions/<name>.meta.json
+		if strings.HasSuffix(name, ".meta.json") {
+			sessionName := strings.TrimSuffix(name, ".meta.json")
+			meta := r.parseSessionMeta(sessionsDir, sessionName)
+			out[sessionName] = *meta
+			continue
+		}
+		// Flat format: sessions/<name>.jsonl — infer from session log
+		if strings.HasSuffix(name, ".jsonl") {
+			sessionName := strings.TrimSuffix(name, ".jsonl")
+			if _, exists := out[sessionName]; !exists {
+				meta := r.parseSessionMeta(sessionsDir, sessionName)
+				out[sessionName] = *meta
+			}
+		}
+	}
+	return out
+}
+
+func (r Reasonix) sessionMetaPath(sessionsDir, sessionName string) string {
+	return filepath.Join(sessionsDir, sessionName, ".meta.json")
+}
+
+func (r Reasonix) sessionMetaPathFlat(sessionsDir, sessionName string) string {
+	return filepath.Join(sessionsDir, sessionName+".meta.json")
+}
+
+func (r Reasonix) sessionLogPath(sessionsDir, sessionName string) string {
+	return filepath.Join(sessionsDir, sessionName, sessionName+".jsonl")
+}
+
+func (r Reasonix) sessionLogPathFlat(sessionsDir, sessionName string) string {
+	return filepath.Join(sessionsDir, sessionName+".jsonl")
+}
+
+type reasonixSessionMeta struct {
+	Workspace string `json:"workspace"`
+	Summary   string `json:"summary"`
+}
+
+func (r Reasonix) parseSessionMeta(sessionsDir, sessionName string) *threadMeta {
+	// Try both path formats for .meta.json
+	metaPath := r.sessionMetaPath(sessionsDir, sessionName)
+	flatMetaPath := r.sessionMetaPathFlat(sessionsDir, sessionName)
+	summary := ""
+	workspace := ""
+
+	data, err := os.ReadFile(metaPath)
+	if err != nil {
+		data, err = os.ReadFile(flatMetaPath)
+	}
+	if err == nil {
+		var meta reasonixSessionMeta
+		if json.Unmarshal(data, &meta) == nil {
+			summary = meta.Summary
+			workspace = meta.Workspace
+		}
+	}
+
+	// Fallback: try first user message from session JSONL
+	firstUser := r.readFirstUserMessage(sessionsDir, sessionName)
+	name := chooseThreadTitle(summary, firstUser, pathBase(workspace), sessionName)
+	return &threadMeta{
+		ID:     sessionName,
+		Name:   name,
+		Source: metaPath,
+	}
+}
+
+func (r Reasonix) readFirstUserMessage(sessionsDir, sessionName string) string {
+	logPath := r.sessionLogPath(sessionsDir, sessionName)
+	data, err := os.ReadFile(logPath)
+	if err != nil {
+		logPath = r.sessionLogPathFlat(sessionsDir, sessionName)
+		data, err = os.ReadFile(logPath)
+	}
+	if err != nil {
+		return ""
+	}
+	// Scan for the first user message
+	lines := 0
+	start := 0
+	for i := 0; i < len(data); i++ {
+		if data[i] == '\n' {
+			line := data[start:i]
+			start = i + 1
+			lines++
+			if lines > 50 {
+				break
+			}
+			var obj map[string]any
+			if json.Unmarshal(line, &obj) != nil {
+				continue
+			}
+			role := stringValue(obj["role"])
+			if role != "user" {
+				continue
+			}
+			text := extractText(obj["content"])
+			if isRealUserTitle(text) {
+				return text
+			}
+		}
+	}
+	return ""
+}
+
+func (r Reasonix) parseEvent(obj map[string]any) (usage.UsageEvent, bool) {
+	ts := intValue(obj["ts"])
+	if ts == 0 {
+		return usage.UsageEvent{}, false
+	}
+	timestamp := time.UnixMilli(ts)
+
+	model := usage.Unknown(stringValue(obj["model"]))
+	if model == "unknown" {
+		return usage.UsageEvent{}, false
+	}
+
+	promptTokens := intValue(obj["promptTokens"])
+	completionTokens := intValue(obj["completionTokens"])
+	cacheHitTokens := intValue(obj["cacheHitTokens"])
+	cacheMissTokens := intValue(obj["cacheMissTokens"])
+
+	tokens := usage.TokenUsage{
+		Input:         promptTokens,
+		Output:        completionTokens,
+		CachedInput:   cacheHitTokens,
+		CacheCreation: cacheMissTokens,
+	}
+	if tokens.NormalizedTotal() == 0 && tokens.CachedInput == 0 {
+		return usage.UsageEvent{}, false
+	}
+
+	session := usage.Unknown(pointersString(obj["session"]))
+	threadID := session
+	threadName := session
+	if session == "unknown" || stringsPointerEmpty(obj["session"]) {
+		id := reasonixEventID(timestamp, model, tokens)
+		threadID = id
+		if stringsPointerEmpty(obj["session"]) {
+			threadName = "(ephemeral)"
+		} else {
+			threadName = id
+		}
+	}
+
+	tsMicro := timestamp.UnixMicro()
+	return usage.UsageEvent{
+		ID:           reasonixUUID(tsMicro, model, tokens),
+		Timestamp:    timestamp,
+		Tool:         usage.ToolReasonix,
+		Model:        model,
+		Provider:     "deepseek",
+		Source:       "reasonix",
+		ThreadID:     threadID,
+		ThreadName:   threadName,
+		ThreadSource: "reasonix",
+		Complete:     true,
+		Usage:        tokens,
+	}, true
+}
+
+func reasonixEventID(ts time.Time, model string, tokens usage.TokenUsage) string {
+	return reasonixUUID(ts.UnixMicro(), model, tokens)
+}
+
+func reasonixUUID(tsMicro int64, model string, tokens usage.TokenUsage) string {
+	h := tsMicro ^ int64(tokens.Input)^int64(tokens.Output)^int64(tokens.CachedInput)^int64(tokens.CacheCreation)
+	return usage.Unknown(model) + "-" + formatInt64(h)
+}
+
+func pointersString(p any) string {
+	if p == nil {
+		return ""
+	}
+	if s, ok := p.(string); ok {
+		return s
+	}
+	return ""
+}
+
+func stringsPointerEmpty(p any) bool {
+	return p == nil || pointersString(p) == ""
+}
+
+func formatInt64(n int64) string {
+	if n < 0 {
+		n = -n
+	}
+	if n < 0 {
+		return "0"
+	}
+	u := uint64(n)
+	alphabet := "0123456789abcdefghijklmnopqrstuv"
+	buf := make([]byte, 13)
+	for i := 12; i >= 0; i-- {
+		buf[i] = alphabet[u%32]
+		u /= 32
+	}
+	i := 0
+	for i < 12 && buf[i] == '0' {
+		i++
+	}
+	return string(buf[i:])
+}
+
+

--- a/internal/sources/sources_test.go
+++ b/internal/sources/sources_test.go
@@ -1951,6 +1951,235 @@ func TestGeminiReadsConfiguredTelemetryOutfile(t *testing.T) {
 	}
 }
 
+func TestReasonixReadsUsageJSONL(t *testing.T) {
+	home := t.TempDir()
+	mustMkdir(t, filepath.Join(home, ".reasonix"))
+	line := `{"ts":1746700000000,"session":"my-project","model":"deepseek-v4-flash","promptTokens":1000,"completionTokens":500,"cacheHitTokens":200,"cacheMissTokens":100,"costUsd":0.042,"claudeEquivUsd":0.15}` + "\n"
+	mustWrite(t, filepath.Join(home, ".reasonix", "usage.jsonl"), line)
+	events, err := NewReasonix(Options{Home: home}).Read(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("len(events) = %d, want 1", len(events))
+	}
+	e := events[0]
+	if e.Tool != usage.ToolReasonix {
+		t.Fatalf("Tool = %q, want reasonix", e.Tool)
+	}
+	if e.Model != "deepseek-v4-flash" {
+		t.Fatalf("Model = %q, want deepseek-v4-flash", e.Model)
+	}
+	if e.Provider != "deepseek" {
+		t.Fatalf("Provider = %q, want deepseek", e.Provider)
+	}
+	if e.Usage.Input != 1000 || e.Usage.Output != 500 || e.Usage.CachedInput != 200 || e.Usage.CacheCreation != 100 {
+		t.Fatalf("Usage = %+v, want input=1000 output=500 cached=200 cacheCreation=100", e.Usage)
+	}
+	if e.ThreadID != "my-project" || e.ThreadName != "my-project" {
+		t.Fatalf("ThreadID=%q ThreadName=%q, want my-project", e.ThreadID, e.ThreadName)
+	}
+	if !e.Complete {
+		t.Fatal("Complete should be true for all reasonix records")
+	}
+}
+
+func TestReasonixNullSessionMapsToEphemeral(t *testing.T) {
+	home := t.TempDir()
+	mustMkdir(t, filepath.Join(home, ".reasonix"))
+	line := `{"ts":1746700000000,"session":null,"model":"deepseek-v4-pro","promptTokens":100,"completionTokens":50,"cacheHitTokens":0,"cacheMissTokens":0,"costUsd":0.01,"claudeEquivUsd":0.03}` + "\n"
+	mustWrite(t, filepath.Join(home, ".reasonix", "usage.jsonl"), line)
+	events, err := NewReasonix(Options{Home: home}).Read(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("len(events) = %d, want 1", len(events))
+	}
+	if events[0].ThreadName != "(ephemeral)" {
+		t.Fatalf("ThreadName = %q, want (ephemeral)", events[0].ThreadName)
+	}
+}
+
+func TestReasonixFiltersByTimeWindow(t *testing.T) {
+	home := t.TempDir()
+	mustMkdir(t, filepath.Join(home, ".reasonix"))
+	// ts for 2025-05-08T01:00:00Z = 1746666000000 ms
+	early := `{"ts":1746666000000,"model":"deepseek-chat","promptTokens":100,"completionTokens":10,"cacheHitTokens":0,"cacheMissTokens":0,"costUsd":0,"claudeEquivUsd":0}` + "\n"
+	onTime := `{"ts":1746669600000,"model":"deepseek-chat","promptTokens":200,"completionTokens":20,"cacheHitTokens":0,"cacheMissTokens":0,"costUsd":0,"claudeEquivUsd":0}` + "\n"
+	late := `{"ts":1746673200000,"model":"deepseek-chat","promptTokens":300,"completionTokens":30,"cacheHitTokens":0,"cacheMissTokens":0,"costUsd":0,"claudeEquivUsd":0}` + "\n"
+	mustWrite(t, filepath.Join(home, ".reasonix", "usage.jsonl"), early+onTime+late)
+
+	start := time.Date(2025, 5, 8, 1, 30, 0, 0, time.UTC)
+	end := time.Date(2025, 5, 8, 2, 30, 0, 0, time.UTC)
+	events, err := NewReasonix(Options{Home: home, WindowStart: start, WindowEnd: end}).Read(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("len(events) = %d, want 1 (only onTime)", len(events))
+	}
+	if events[0].Usage.Input != 200 {
+		t.Fatalf("Usage.Input = %d, want 200", events[0].Usage.Input)
+	}
+}
+
+func TestReasonixSkipsEmptyFile(t *testing.T) {
+	home := t.TempDir()
+	// No .reasonix directory at all — should return no events, not error
+	events, err := NewReasonix(Options{Home: home}).Read(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(events) != 0 {
+		t.Fatalf("len(events) = %d, want 0", len(events))
+	}
+}
+
+func TestReasonixSkipsRecordWithoutModel(t *testing.T) {
+	home := t.TempDir()
+	mustMkdir(t, filepath.Join(home, ".reasonix"))
+	// No model field
+	line := `{"ts":1746700000000,"promptTokens":100,"completionTokens":10,"cacheHitTokens":0,"cacheMissTokens":0,"costUsd":0,"claudeEquivUsd":0}` + "\n"
+	mustWrite(t, filepath.Join(home, ".reasonix", "usage.jsonl"), line)
+	events, err := NewReasonix(Options{Home: home}).Read(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(events) != 0 {
+		t.Fatalf("len(events) = %d, want 0", len(events))
+	}
+}
+
+func TestReasonixHandlesCacheOnlyEvent(t *testing.T) {
+	home := t.TempDir()
+	mustMkdir(t, filepath.Join(home, ".reasonix"))
+	line := `{"ts":1746700000000,"session":"cache-test","model":"deepseek-v4-flash","promptTokens":0,"completionTokens":0,"cacheHitTokens":500,"cacheMissTokens":0,"costUsd":0.0014,"claudeEquivUsd":0.005}` + "\n"
+	mustWrite(t, filepath.Join(home, ".reasonix", "usage.jsonl"), line)
+	events, err := NewReasonix(Options{Home: home}).Read(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("len(events) = %d, want 1", len(events))
+	}
+	if events[0].Usage.CachedInput != 500 || events[0].Usage.Input != 0 {
+		t.Fatalf("cache-only event: %+v", events[0].Usage)
+	}
+}
+
+func TestReasonixSessionMetaEnrichesThreadName(t *testing.T) {
+	home := t.TempDir()
+	mustMkdir(t, filepath.Join(home, ".reasonix"))
+	mustMkdir(t, filepath.Join(home, ".reasonix", "sessions", "code-aitok"))
+	// .meta.json with workspace and summary
+	meta := `{"workspace":"/Users/dev/projects/aitok","summary":"Fix TUI currency display"}`
+	mustWrite(t, filepath.Join(home, ".reasonix", "sessions", "code-aitok", ".meta.json"), meta)
+	line := `{"ts":1746700000000,"session":"code-aitok","model":"deepseek-v4-flash","promptTokens":1000,"completionTokens":500,"cacheHitTokens":0,"cacheMissTokens":0,"costUsd":0.042,"claudeEquivUsd":0.15}` + "\n"
+	mustWrite(t, filepath.Join(home, ".reasonix", "usage.jsonl"), line)
+	events, err := NewReasonix(Options{Home: home}).Read(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("len(events) = %d, want 1", len(events))
+	}
+	// ThreadName should be the summary from .meta.json, not "code-aitok"
+	if events[0].ThreadName != "Fix TUI currency display" {
+		t.Fatalf("ThreadName = %q, want \"Fix TUI currency display\"", events[0].ThreadName)
+	}
+	if events[0].ThreadID != "code-aitok" {
+		t.Fatalf("ThreadID = %q, want code-aitok", events[0].ThreadID)
+	}
+}
+
+func TestReasonixSessionMetaReadsFirstUserMessage(t *testing.T) {
+	home := t.TempDir()
+	mustMkdir(t, filepath.Join(home, ".reasonix"))
+	sessionDir := filepath.Join(home, ".reasonix", "sessions", "code-aitok")
+	mustMkdir(t, sessionDir)
+	// No .meta.json — fallback to session JSONL first user message
+	chatLine := `{"role":"user","content":[{"text":"Fix the currency display bug"}]}` + "\n"
+	mustWrite(t, filepath.Join(sessionDir, "code-aitok.jsonl"), chatLine)
+	line := `{"ts":1746700000000,"session":"code-aitok","model":"deepseek-v4-flash","promptTokens":100,"completionTokens":10,"cacheHitTokens":0,"cacheMissTokens":0,"costUsd":0.001,"claudeEquivUsd":0.003}` + "\n"
+	mustWrite(t, filepath.Join(home, ".reasonix", "usage.jsonl"), line)
+	events, err := NewReasonix(Options{Home: home}).Read(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("len(events) = %d, want 1", len(events))
+	}
+	if events[0].ThreadName != "Fix the currency display bug" {
+		t.Fatalf("ThreadName = %q, want \"Fix the currency display bug\"", events[0].ThreadName)
+	}
+}
+
+func TestReasonixSessionMetaFlatFormat(t *testing.T) {
+	home := t.TempDir()
+	sessionsDir := filepath.Join(home, ".reasonix", "sessions")
+	mustMkdir(t, filepath.Join(home, ".reasonix"))
+	mustMkdir(t, sessionsDir)
+	// Flat format: sessions/<name>.meta.json (not a directory)
+	meta := `{"workspace":"/Users/dev/projects/aitok","summary":"Add reasonix source"}`
+	mustWrite(t, filepath.Join(sessionsDir, "code-aitok.meta.json"), meta)
+	line := `{"ts":1746700000000,"session":"code-aitok","model":"deepseek-v4-flash","promptTokens":100,"completionTokens":10,"cacheHitTokens":0,"cacheMissTokens":0,"costUsd":0.001,"claudeEquivUsd":0.003}` + "\n"
+	mustWrite(t, filepath.Join(home, ".reasonix", "usage.jsonl"), line)
+	events, err := NewReasonix(Options{Home: home}).Read(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("len(events) = %d, want 1", len(events))
+	}
+	if events[0].ThreadName != "Add reasonix source" {
+		t.Fatalf("ThreadName = %q, want \"Add reasonix source\"", events[0].ThreadName)
+	}
+}
+
+func TestReasonixSessionMetaFromFlatJSONL(t *testing.T) {
+	home := t.TempDir()
+	sessionsDir := filepath.Join(home, ".reasonix", "sessions")
+	mustMkdir(t, filepath.Join(home, ".reasonix"))
+	mustMkdir(t, sessionsDir)
+	// Flat format: sessions/<name>.jsonl with first user message (no .meta.json)
+	chatLine := `{"role":"user","content":[{"text":"Implement reasonix support"}]}` + "\n"
+	mustWrite(t, filepath.Join(sessionsDir, "code-aitok.jsonl"), chatLine)
+	line := `{"ts":1746700000000,"session":"code-aitok","model":"deepseek-v4-flash","promptTokens":100,"completionTokens":10,"cacheHitTokens":0,"cacheMissTokens":0,"costUsd":0.001,"claudeEquivUsd":0.003}` + "\n"
+	mustWrite(t, filepath.Join(home, ".reasonix", "usage.jsonl"), line)
+	events, err := NewReasonix(Options{Home: home}).Read(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("len(events) = %d, want 1", len(events))
+	}
+	if events[0].ThreadName != "Implement reasonix support" {
+		t.Fatalf("ThreadName = %q, want \"Implement reasonix support\"", events[0].ThreadName)
+	}
+}
+
+func TestReasonixSessionMetaFallbackToWorkspace(t *testing.T) {
+	home := t.TempDir()
+	mustMkdir(t, filepath.Join(home, ".reasonix"))
+	mustMkdir(t, filepath.Join(home, ".reasonix", "sessions", "my-project"))
+	// .meta.json with only workspace, no summary
+	meta := `{"workspace":"/Users/dev/my-project"}`
+	mustWrite(t, filepath.Join(home, ".reasonix", "sessions", "my-project", ".meta.json"), meta)
+	line := `{"ts":1746700000000,"session":"my-project","model":"deepseek-v4-flash","promptTokens":100,"completionTokens":10,"cacheHitTokens":0,"cacheMissTokens":0,"costUsd":0.001,"claudeEquivUsd":0.003}` + "\n"
+	mustWrite(t, filepath.Join(home, ".reasonix", "usage.jsonl"), line)
+	events, err := NewReasonix(Options{Home: home}).Read(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("len(events) = %d, want 1", len(events))
+	}
+	if events[0].ThreadName != "my-project" {
+		t.Fatalf("ThreadName = %q, want my-project (fallback to workspace base)", events[0].ThreadName)
+	}
+}
+
 func TestGeminiSkipsUsageWithoutTimestamp(t *testing.T) {
 	home := t.TempDir()
 	mustMkdir(t, filepath.Join(home, ".gemini"))

--- a/internal/tui/filters.go
+++ b/internal/tui/filters.go
@@ -10,6 +10,7 @@ import (
 type totals struct {
 	requests int
 	cost     float64
+	currency string
 	total    int64
 	cached   int64
 }
@@ -63,6 +64,9 @@ func summarize(results []query.Result) totals {
 		out.cost += result.CostUSD
 		out.total += result.Usage.NormalizedTotal()
 		out.cached += result.Usage.CachedInput + result.Usage.CacheCreation
+		if result.Price != nil && result.Price.Currency != "" && out.currency == "" {
+			out.currency = result.Price.Currency
+		}
 	}
 	return out
 }

--- a/internal/tui/filters.go
+++ b/internal/tui/filters.go
@@ -9,8 +9,7 @@ import (
 
 type totals struct {
 	requests int
-	cost     float64
-	currency string
+	costs    map[string]float64
 	total    int64
 	cached   int64
 }
@@ -58,15 +57,12 @@ func (m model) filteredResults() []query.Result {
 }
 
 func summarize(results []query.Result) totals {
-	var out totals
+	out := totals{costs: map[string]float64{}}
 	for _, result := range results {
 		out.requests += result.Requests
-		out.cost += result.CostUSD
 		out.total += result.Usage.NormalizedTotal()
 		out.cached += result.Usage.CachedInput + result.Usage.CacheCreation
-		if result.Price != nil && result.Price.Currency != "" && out.currency == "" {
-			out.currency = result.Price.Currency
-		}
+		out.costs[resultCurrency2(result)] += result.CostUSD
 	}
 	return out
 }

--- a/internal/tui/format.go
+++ b/internal/tui/format.go
@@ -84,6 +84,62 @@ func tuiFormatCost(value float64, currency string) string {
 	return report.FormatCost(value, currency)
 }
 
+func tuiFormatCosts(costs map[string]float64) string {
+	if len(costs) == 0 {
+		return tuiFormatCost(0, "USD")
+	}
+	usd := costs["USD"]
+	cny := costs["CNY"] + costs["RMB"]
+	parts := make([]string, 0, len(costs))
+	if usd != 0 || cny == 0 {
+		parts = append(parts, tuiFormatCost(usd, "USD"))
+	}
+	if cny != 0 {
+		cnyPart := tuiFormatCost(cny, "CNY")
+		if len(parts) == 0 {
+			parts = append(parts, cnyPart)
+		} else {
+			parts = append(parts, "("+cnyPart+")")
+		}
+	}
+	otherCurrencies := make([]string, 0, len(costs))
+	for currency := range costs {
+		upper := strings.ToUpper(currency)
+		if upper == "" || upper == "USD" || upper == "CNY" || upper == "RMB" {
+			continue
+		}
+		otherCurrencies = append(otherCurrencies, currency)
+	}
+	sort.Strings(otherCurrencies)
+	for _, currency := range otherCurrencies {
+		parts = append(parts, "("+tuiFormatCost(costs[currency], currency)+")")
+	}
+	return strings.Join(parts, " ")
+}
+
+func tuiPrimaryCurrency(costs map[string]float64) string {
+	if len(costs) == 0 {
+		return "USD"
+	}
+	if costs["USD"] != 0 {
+		return "USD"
+	}
+	if costs["CNY"] != 0 || costs["RMB"] != 0 {
+		return "CNY"
+	}
+	currencies := make([]string, 0, len(costs))
+	for currency, amount := range costs {
+		if amount != 0 {
+			currencies = append(currencies, currency)
+		}
+	}
+	if len(currencies) == 0 {
+		return "USD"
+	}
+	sort.Strings(currencies)
+	return currencies[0]
+}
+
 func tuiCurrencyIcon(currency string) string {
 	switch strings.ToUpper(currency) {
 	case "CNY", "RMB":

--- a/internal/tui/format.go
+++ b/internal/tui/format.go
@@ -38,17 +38,18 @@ func resultLabel(result query.Result) string {
 }
 
 func tuiThreadCost(thread query.ThreadResult) string {
-	return report.FormatUSD(thread.CostUSD)
+	return tuiFormatCost(thread.CostUSD, threadCurrency2(thread))
 }
 
 func tuiThreadCostDetail(thread query.ThreadResult) string {
+	cur := threadCurrency2(thread)
 	totalUSD := thread.CostUSD
 	if totalUSD == 0 && len(thread.CostBreakdown) > 0 {
 		for _, item := range thread.CostBreakdown {
 			totalUSD += item.USD
 		}
 	}
-	total := report.FormatUSD(totalUSD)
+	total := tuiFormatCost(totalUSD, cur)
 	if len(thread.CostBreakdown) == 0 {
 		return total
 	}
@@ -57,12 +58,39 @@ func tuiThreadCostDetail(thread query.ThreadResult) string {
 		if item.Provider == "" {
 			continue
 		}
-		parts = append(parts, item.Provider+" "+report.FormatUSD(item.USD))
+		parts = append(parts, item.Provider+" "+tuiFormatCost(item.USD, cur))
 	}
 	if len(parts) == 0 {
 		return total
 	}
 	return total + " (" + strings.Join(parts, " / ") + ")"
+}
+
+func threadCurrency2(thread query.ThreadResult) string {
+	if thread.Price != nil && thread.Price.Currency != "" {
+		return thread.Price.Currency
+	}
+	return "USD"
+}
+
+func resultCurrency2(result query.Result) string {
+	if result.Price != nil && result.Price.Currency != "" {
+		return result.Price.Currency
+	}
+	return "USD"
+}
+
+func tuiFormatCost(value float64, currency string) string {
+	return report.FormatCost(value, currency)
+}
+
+func tuiCurrencyIcon(currency string) string {
+	switch strings.ToUpper(currency) {
+	case "CNY", "RMB":
+		return "¥"
+	default:
+		return "$"
+	}
 }
 
 func primaryThreadValue(value string) string {

--- a/internal/tui/layout.go
+++ b/internal/tui/layout.go
@@ -44,7 +44,7 @@ func threadRowWithWidth(id, name, tool, req, cost, tokens string, maxWidth int) 
 	gaps := []int{2, 2, 3, 4, 3}
 	nameWidth := 38
 	if maxWidth > 0 {
-		fixedWidth := 14 + 6 + 5 + 11 + 9
+		fixedWidth := 14 + 10 + 5 + 11 + 9
 		for _, gap := range gaps {
 			fixedWidth += gap
 		}
@@ -56,7 +56,7 @@ func threadRowWithWidth(id, name, tool, req, cost, tokens string, maxWidth int) 
 	columns := []tableColumn{
 		{value: id, width: 14, align: alignLeft},
 		{value: name, width: nameWidth, align: alignLeft},
-		{value: tool, width: 6, align: alignLeft},
+		{value: tool, width: 10, align: alignLeft},
 		{value: req, width: 5, align: alignRight},
 		{value: cost, width: 11, align: alignRight},
 		{value: tokens, width: 9, align: alignRight},

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -180,6 +180,10 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.activeTool = string(usage.ToolGemini)
 			m.ensureThreadVisible()
 			m.ensureModelUsageVisible()
+		case "5":
+			m.activeTool = string(usage.ToolReasonix)
+			m.ensureThreadVisible()
+			m.ensureModelUsageVisible()
 		case "tab":
 			m.toggleFocusedPane()
 		case "pgup", "ctrl+u":

--- a/internal/tui/tui_test.go
+++ b/internal/tui/tui_test.go
@@ -357,6 +357,34 @@ func TestModelUsageTableShowsPriceSourceAndRates(t *testing.T) {
 	}
 }
 
+func TestEstimatedCostCardSeparatesUSDAndCNY(t *testing.T) {
+	payload := report.Payload{
+		Results: []query.Result{
+			{
+				Key:      map[string]string{"tool": "codex", "model": "gpt-5.4"},
+				Requests: 1,
+				Usage:    usage.TokenUsage{Input: 1_000_000},
+				CostUSD:  1.25,
+				Price:    &query.Price{Source: "official", Currency: "USD"},
+			},
+			{
+				Key:      map[string]string{"tool": "reasonix", "model": "deepseek-v4-flash"},
+				Requests: 1,
+				Usage:    usage.TokenUsage{Input: 1_000_000, Output: 500_000},
+				CostUSD:  2,
+				Price:    &query.Price{Source: "default", Currency: "CNY"},
+			},
+		},
+	}
+	view := stripANSI(RenderWidth(payload, 140))
+	if !strings.Contains(view, "$1.2500 (¥2.0000)") {
+		t.Fatalf("estimated cost should show USD first and CNY separately: %s", view)
+	}
+	if strings.Contains(view, "$3.2500") || strings.Contains(view, "¥3.2500") {
+		t.Fatalf("estimated cost should not merge different currencies: %s", view)
+	}
+}
+
 func TestModelUsageTableShowsMixedPriceDetails(t *testing.T) {
 	payload := report.Payload{
 		Results: []query.Result{

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -4,7 +4,6 @@ import (
 	"strings"
 
 	"github.com/MagnumGoYB/aitok/internal/query"
-	"github.com/MagnumGoYB/aitok/internal/report"
 	"github.com/MagnumGoYB/aitok/internal/usage"
 	"github.com/charmbracelet/lipgloss"
 )
@@ -85,6 +84,7 @@ func (m model) toolbar(copy localizedCopy) string {
 		m.tab(string(usage.ToolClaude), "Claude Code"),
 		m.tab(string(usage.ToolCodex), "Codex"),
 		m.tab(string(usage.ToolGemini), "Gemini"),
+		m.tab(string(usage.ToolReasonix), "Reasonix"),
 	}
 	top := strings.Join(tabs, "  ")
 	separator := toolbarSeparator(dashboardWidth(m.width) - 6)
@@ -192,7 +192,7 @@ func (m model) cards(summary totals, copy localizedCopy) string {
 	}
 	cards := []string{
 		cardWithWidth(copy.requests, formatInt(int64(summary.requests)), "↯", blue, cardWidths[0]),
-		cardWithWidth(copy.cost, report.FormatUSD(summary.cost), "$", green, cardWidths[1]),
+		cardWithWidth(copy.cost, tuiFormatCost(summary.cost, summary.currency), tuiCurrencyIcon(summary.currency), green, cardWidths[1]),
 		cardWithWidth(copy.totalTokens, formatInt(summary.total), "▱", purple, cardWidths[2]),
 		cardWithWidth(copy.cachedTokens, formatInt(summary.cached), "◉", orange, cardWidths[3]),
 	}

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -192,7 +192,7 @@ func (m model) cards(summary totals, copy localizedCopy) string {
 	}
 	cards := []string{
 		cardWithWidth(copy.requests, formatInt(int64(summary.requests)), "↯", blue, cardWidths[0]),
-		cardWithWidth(copy.cost, tuiFormatCost(summary.cost, summary.currency), tuiCurrencyIcon(summary.currency), green, cardWidths[1]),
+		cardWithWidth(copy.cost, tuiFormatCosts(summary.costs), tuiCurrencyIcon(tuiPrimaryCurrency(summary.costs)), green, cardWidths[1]),
 		cardWithWidth(copy.totalTokens, formatInt(summary.total), "▱", purple, cardWidths[2]),
 		cardWithWidth(copy.cachedTokens, formatInt(summary.cached), "◉", orange, cardWidths[3]),
 	}

--- a/internal/tui/widgets_model_usage.go
+++ b/internal/tui/widgets_model_usage.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 
 	"github.com/MagnumGoYB/aitok/internal/query"
-	"github.com/MagnumGoYB/aitok/internal/report"
 	"github.com/charmbracelet/lipgloss"
 )
 
@@ -77,7 +76,7 @@ func (m model) modelUsageMetricValue(result query.Result) float64 {
 
 func (m model) modelUsageMetricLabel(result query.Result) string {
 	if normalizePayloadSort(m.sortBy) == query.SortByCost {
-		return report.FormatUSD(result.CostUSD)
+		return tuiFormatCost(result.CostUSD, resultCurrency2(result))
 	}
 	return formatInt(result.Usage.NormalizedTotal())
 }
@@ -106,7 +105,7 @@ func (m model) tableLines(results []query.Result, copy localizedCopy) []string {
 		line := modelUsageTableLine(modelTableRow(
 			resultLabel(result),
 			fmt.Sprint(result.Requests),
-			report.FormatUSD(result.CostUSD),
+			tuiFormatCost(result.CostUSD, resultCurrency2(result)),
 			priceLabel(result.Price, result.PriceSource),
 			compact(result.Usage.NormalizedTotal()),
 			compact(result.Usage.Input),

--- a/internal/usage/usage.go
+++ b/internal/usage/usage.go
@@ -5,9 +5,10 @@ import "time"
 type Tool string
 
 const (
-	ToolClaude Tool = "claude"
-	ToolCodex  Tool = "codex"
-	ToolGemini Tool = "gemini"
+	ToolClaude   Tool = "claude"
+	ToolCodex    Tool = "codex"
+	ToolGemini   Tool = "gemini"
+	ToolReasonix Tool = "reasonix"
 )
 
 type TokenUsage struct {

--- a/tools/commitlint/main.go
+++ b/tools/commitlint/main.go
@@ -19,7 +19,7 @@ var (
 	headerPattern       = regexp.MustCompile(`^(\S+)\s+([a-z]+)(?:\(([^)]+)\))?:\s+(.+)$`)
 	missingEmojiPattern = regexp.MustCompile(`^[a-z]+(?:\([^)]+\))?:\s+.+$`)
 	allowedTypeValues   = []string{"feat", "fix", "docs", "ci", "style", "refactor", "release", "perf", "test", "chore", "build"}
-	allowedScopeValues  = []string{"cli", "sources", "query", "report", "setup", "tui", "usage", "harness", "docs", "github", "config", "deps", "build", "tests", "release"}
+	allowedScopeValues  = []string{"cli", "sources", "query", "report", "setup", "tui", "usage", "harness", "docs", "github", "config", "deps", "build", "tests", "release", "reasonix"}
 	allowedTypes        = set(allowedTypeValues...)
 	allowedScopes       = set(allowedScopeValues...)
 	typeEmojiValues     = map[string]string{
@@ -51,6 +51,7 @@ var (
 		"build",
 		"tests",
 		"release",
+		"reasonix",
 	}, ", ")
 )
 


### PR DESCRIPTION
## Summary

Add Reasonix data source support with DeepSeek model CNY native pricing. User-visible outcome: `aitok summary` and `aitok tui` now show Reasonix token usage and display DeepSeek costs in CNY.

## Requirement Classification

Feature — new tool source adapter.

## Acceptance Criteria

- [x] Reasonix usage.jsonl reading with correct field mapping
- [x] DeepSeek model pricing matching (v4-flash, v4-pro, chat, reasoner)
- [x] DeepSeek CNY unit pricing remains native and is not normalized to USD
- [x] Cost sorting compares raw numeric amounts without currency conversion
- [x] Thread name extraction from session metadata
- [x] TUI key-5 for Reasonix tool filter
- [x] Budget check only sums USD costs; CNY totals stay separate

### Acceptance Criteria Evidence Map

| Criterion | Evidence |
|-----------|----------|
| usage.jsonl parsing | `internal/sources/sources_test.go` Reasonix tests cover normal JSONL, empty/missing source, malformed/missing fields, cache-only events, null session, time filtering, and metadata enrichment |
| DeepSeek pricing | `TestDefaultCatalogCoversDeepSeekModels` verifies v4-flash, v4-pro, chat, and reasoner are priced in CNY |
| CNY remains native | pricing/report tests verify DeepSeek CNY amounts stay native and display as `¥` |
| raw cost sorting | `TestAggregateSortsCostByRawAmountAcrossCurrencies` verifies cost sort compares numeric amounts without currency conversion |
| thread names | `TestReasonixSessionMetaEnrichesThreadName` and flat session metadata tests |
| TUI key-5 | TUI model/view changes and existing TUI package validation |
| budget USD-only | `TestBudgetCheckExcludesCNYFromUSDLimit` verifies CNY totals are excluded from `--limit-usd` and reported separately |

## Changed Areas

- `internal/sources/reasonix.go` — Source adapter
- `internal/pricing/pricing.go` — DeepSeek CNY pricing entries and native CNY cost calculation
- `internal/query/query.go` — Cost/Price.Currency propagation and raw cost sorting
- `internal/report/report.go` — Currency-aware cost display
- `internal/tui/*` — Reasonix tab and CNY cost display
- `internal/usage/usage.go` — ToolReasonix constant
- `tools/commitlint/main.go` — reasonix scope

## Release Decision

Release required after merge — feature/bugfix affects CLI output and source coverage.

## TDD / Test Evidence

Test-first/sensor-first evidence: Reasonix parser, CNY pricing, budget separation, and raw sorting behavior are covered with focused unit tests before handoff.

Failure/edge coverage: empty Reasonix source, malformed JSONL, missing model, zero-token/cache-only events, null session, multiple session metadata layouts, first-user-message fallback, and CNY-only budget checks.

## Validation

- `make validate`: passes locally
- GitHub checks: pending for latest push

Skipped validation: none.

## Risk and Rollback

Residual risk: CNY amounts remain in legacy `cost_usd` fields for now to preserve the existing aggregation shape while currency metadata identifies the unit. Rollback: revert PR commits; no data migration required.
