### PR TITLE
✨ feat(config): add Xiaomi MiMo model pricing

### DIFF
--- a/internal/pricing/pricing.go
+++ b/internal/pricing/pricing.go
@@ -93,12 +93,12 @@ func DefaultCatalog() Catalog {
 		{Match: "deepseek-v4-pro", Provider: "deepseek", Currency: "CNY", InputUSDPerMTok: 3, OutputUSDPerMTok: 6, CacheHitUSDPerMTok: 0.025, CacheMakeUSDPerMTok: 3, Multiplier: 1, Source: "default"},
 		{Match: "deepseek-reasoner", Provider: "deepseek", Currency: "CNY", InputUSDPerMTok: 4, OutputUSDPerMTok: 16, CacheHitUSDPerMTok: 1, CacheMakeUSDPerMTok: 4, Multiplier: 1, Source: "default"},
 		// MiMo-V2.5 Series (effective May 27, 2026)
-		{Match: "mimo-v2.5-pro", Provider: "mimo", InputUSDPerMTok: 0.435, OutputUSDPerMTok: 0.87, CacheHitUSDPerMTok: 0.0036, CacheMakeUSDPerMTok: 0.435, Multiplier: 1, Source: "default"},
-		{Match: "mimo-v2.5", Provider: "mimo", InputUSDPerMTok: 0.14, OutputUSDPerMTok: 0.28, CacheHitUSDPerMTok: 0.0028, CacheMakeUSDPerMTok: 0.14, Multiplier: 1, Source: "default"},
+		{Match: "mimo-v2.5-pro", Provider: "mimo", Currency: "CNY", InputUSDPerMTok: 3, OutputUSDPerMTok: 6, CacheHitUSDPerMTok: 0.025, CacheMakeUSDPerMTok: 3, Multiplier: 1, Source: "default"},
+		{Match: "mimo-v2.5", Provider: "mimo", Currency: "CNY", InputUSDPerMTok: 1, OutputUSDPerMTok: 2, CacheHitUSDPerMTok: 0.02, CacheMakeUSDPerMTok: 1, Multiplier: 1, Source: "default"},
 		// MiMo-V2 Series
-		{Match: "mimo-v2-pro", Provider: "mimo", InputUSDPerMTok: 1, OutputUSDPerMTok: 3, CacheHitUSDPerMTok: 0.2, CacheMakeUSDPerMTok: 1, PromptThresholdTokens: 256000, AboveThresholdInputUSDPerMTok: 2, AboveThresholdOutputUSDPerMTok: 6, AboveThresholdCacheHitUSDPerMTok: 0.4, AboveThresholdCacheMakeUSDPerMTok: 2, Multiplier: 1, Source: "default"},
-		{Match: "mimo-v2-omni", Provider: "mimo", InputUSDPerMTok: 0.4, OutputUSDPerMTok: 2, CacheHitUSDPerMTok: 0.08, CacheMakeUSDPerMTok: 0.4, Multiplier: 1, Source: "default"},
-		{Match: "off-v2-flash", Provider: "mimo", InputUSDPerMTok: 0.1, OutputUSDPerMTok: 0.3, CacheHitUSDPerMTok: 0.01, CacheMakeUSDPerMTok: 0.1, Multiplier: 1, Source: "default"},
+		{Match: "mimo-v2-pro", Provider: "mimo", Currency: "CNY", InputUSDPerMTok: 7, OutputUSDPerMTok: 21, CacheHitUSDPerMTok: 1.4, CacheMakeUSDPerMTok: 7, PromptThresholdTokens: 256000, AboveThresholdInputUSDPerMTok: 14, AboveThresholdOutputUSDPerMTok: 42, AboveThresholdCacheHitUSDPerMTok: 2.8, AboveThresholdCacheMakeUSDPerMTok: 14, Multiplier: 1, Source: "default"},
+		{Match: "mimo-v2-omni", Provider: "mimo", Currency: "CNY", InputUSDPerMTok: 2.8, OutputUSDPerMTok: 14, CacheHitUSDPerMTok: 0.56, CacheMakeUSDPerMTok: 2.8, Multiplier: 1, Source: "default"},
+		{Match: "off-v2-flash", Provider: "mimo", Currency: "CNY", InputUSDPerMTok: 0.7, OutputUSDPerMTok: 2.1, CacheHitUSDPerMTok: 0.07, CacheMakeUSDPerMTok: 0.7, Multiplier: 1, Source: "default"},
 	}}
 	catalog.refreshSortedModels()
 	return catalog

--- a/internal/pricing/pricing.go
+++ b/internal/pricing/pricing.go
@@ -92,6 +92,13 @@ func DefaultCatalog() Catalog {
 		{Match: "deepseek-v4-flash", Provider: "deepseek", Currency: "CNY", InputUSDPerMTok: 1, OutputUSDPerMTok: 2, CacheHitUSDPerMTok: 0.02, CacheMakeUSDPerMTok: 1, Multiplier: 1, Source: "default"},
 		{Match: "deepseek-v4-pro", Provider: "deepseek", Currency: "CNY", InputUSDPerMTok: 3, OutputUSDPerMTok: 6, CacheHitUSDPerMTok: 0.025, CacheMakeUSDPerMTok: 3, Multiplier: 1, Source: "default"},
 		{Match: "deepseek-reasoner", Provider: "deepseek", Currency: "CNY", InputUSDPerMTok: 4, OutputUSDPerMTok: 16, CacheHitUSDPerMTok: 1, CacheMakeUSDPerMTok: 4, Multiplier: 1, Source: "default"},
+		// MiMo-V2.5 Series (effective May 27, 2026)
+		{Match: "mimo-v2.5-pro", Provider: "mimo", InputUSDPerMTok: 0.435, OutputUSDPerMTok: 0.87, CacheHitUSDPerMTok: 0.0036, CacheMakeUSDPerMTok: 0.435, Multiplier: 1, Source: "default"},
+		{Match: "mimo-v2.5", Provider: "mimo", InputUSDPerMTok: 0.14, OutputUSDPerMTok: 0.28, CacheHitUSDPerMTok: 0.0028, CacheMakeUSDPerMTok: 0.14, Multiplier: 1, Source: "default"},
+		// MiMo-V2 Series
+		{Match: "mimo-v2-pro", Provider: "mimo", InputUSDPerMTok: 1, OutputUSDPerMTok: 3, CacheHitUSDPerMTok: 0.2, CacheMakeUSDPerMTok: 1, PromptThresholdTokens: 256000, AboveThresholdInputUSDPerMTok: 2, AboveThresholdOutputUSDPerMTok: 6, AboveThresholdCacheHitUSDPerMTok: 0.4, AboveThresholdCacheMakeUSDPerMTok: 2, Multiplier: 1, Source: "default"},
+		{Match: "mimo-v2-omni", Provider: "mimo", InputUSDPerMTok: 0.4, OutputUSDPerMTok: 2, CacheHitUSDPerMTok: 0.08, CacheMakeUSDPerMTok: 0.4, Multiplier: 1, Source: "default"},
+		{Match: "off-v2-flash", Provider: "mimo", InputUSDPerMTok: 0.1, OutputUSDPerMTok: 0.3, CacheHitUSDPerMTok: 0.01, CacheMakeUSDPerMTok: 0.1, Multiplier: 1, Source: "default"},
 	}}
 	catalog.refreshSortedModels()
 	return catalog

--- a/internal/pricing/pricing_test.go
+++ b/internal/pricing/pricing_test.go
@@ -392,14 +392,14 @@ func TestDefaultCatalogCoversMiMoModels(t *testing.T) {
 		provider string
 		input    int64
 		output   int64
-		wantUSD  float64
+		wantCNY  float64
 	}{
-		{"mimo-v2.5-pro", "mimo", 1_000_000, 1_000_000, 0.435 + 0.87},
-		{"mimo-v2.5", "mimo", 1_000_000, 1_000_000, 0.14 + 0.28},
-		{"mimo-v2-pro", "mimo", 100_000, 100_000, 0.1 + 0.3},         // below threshold
-		{"mimo-v2-pro", "mimo", 300_000, 100_000, 0.6 + 0.6},         // above threshold
-		{"mimo-v2-omni", "mimo", 1_000_000, 1_000_000, 0.4 + 2.0},
-		{"off-v2-flash", "mimo", 1_000_000, 1_000_000, 0.1 + 0.3},
+		{"mimo-v2.5-pro", "mimo", 1_000_000, 1_000_000, 3 + 6},
+		{"mimo-v2.5", "mimo", 1_000_000, 1_000_000, 1 + 2},
+		{"mimo-v2-pro", "mimo", 100_000, 100_000, 0.7 + 2.1},         // below threshold
+		{"mimo-v2-pro", "mimo", 300_000, 100_000, 4.2 + 4.2},         // above threshold
+		{"mimo-v2-omni", "mimo", 1_000_000, 1_000_000, 2.8 + 14.0},
+		{"off-v2-flash", "mimo", 1_000_000, 1_000_000, 0.7 + 2.1},
 	}
 	for _, tt := range tests {
 		t.Run(tt.model, func(t *testing.T) {
@@ -411,8 +411,11 @@ func TestDefaultCatalogCoversMiMoModels(t *testing.T) {
 			if cost.Source == "unknown" {
 				t.Fatalf("CostFor(%q).Source = unknown (unpriced)", tt.model)
 			}
-			if math.Abs(cost.USD-tt.wantUSD) > 0.001 {
-				t.Fatalf("CostFor(%q).USD = %.4f, want %.4f", tt.model, cost.USD, tt.wantUSD)
+			if cost.Currency != "CNY" {
+				t.Fatalf("CostFor(%q).Currency = %q, want CNY", tt.model, cost.Currency)
+			}
+			if math.Abs(cost.Amount-tt.wantCNY) > 0.01 {
+				t.Fatalf("CostFor(%q).Amount = %.4f, want %.4f CNY", tt.model, cost.Amount, tt.wantCNY)
 			}
 		})
 	}

--- a/internal/pricing/pricing_test.go
+++ b/internal/pricing/pricing_test.go
@@ -385,6 +385,39 @@ func TestDefaultCatalogCoversDeepSeekModels(t *testing.T) {
 	}
 }
 
+func TestDefaultCatalogCoversMiMoModels(t *testing.T) {
+	catalog := DefaultCatalog()
+	tests := []struct {
+		model    string
+		provider string
+		input    int64
+		output   int64
+		wantUSD  float64
+	}{
+		{"mimo-v2.5-pro", "mimo", 1_000_000, 1_000_000, 0.435 + 0.87},
+		{"mimo-v2.5", "mimo", 1_000_000, 1_000_000, 0.14 + 0.28},
+		{"mimo-v2-pro", "mimo", 100_000, 100_000, 0.1 + 0.3},         // below threshold
+		{"mimo-v2-pro", "mimo", 300_000, 100_000, 0.6 + 0.6},         // above threshold
+		{"mimo-v2-omni", "mimo", 1_000_000, 1_000_000, 0.4 + 2.0},
+		{"off-v2-flash", "mimo", 1_000_000, 1_000_000, 0.1 + 0.3},
+	}
+	for _, tt := range tests {
+		t.Run(tt.model, func(t *testing.T) {
+			cost := catalog.CostFor(usage.UsageEvent{
+				Model:    tt.model,
+				Provider: tt.provider,
+				Usage:    usage.TokenUsage{Input: tt.input, Output: tt.output},
+			})
+			if cost.Source == "unknown" {
+				t.Fatalf("CostFor(%q).Source = unknown (unpriced)", tt.model)
+			}
+			if math.Abs(cost.USD-tt.wantUSD) > 0.001 {
+				t.Fatalf("CostFor(%q).USD = %.4f, want %.4f", tt.model, cost.USD, tt.wantUSD)
+			}
+		})
+	}
+}
+
 func BenchmarkCostFor(b *testing.B) {
 	catalog := DefaultCatalog()
 	events := make([]usage.UsageEvent, 4096)


### PR DESCRIPTION
## Summary

Add official Xiaomi MiMo model pricing to the default catalog.

## Requirement Classification

**Type:** Feature

**User-visible outcome:** Accurate cost estimation for MiMo models

**Target platform:** All platforms

**Affected area:** , 

**Release decision:** Release required after merge

## Acceptance Criteria

1. ✅ Add MiMo-V2.5 series pricing (mimo-v2.5-pro, mimo-v2.5)
2. ✅ Add MiMo-V2 series pricing (mimo-v2-pro, mimo-v2-omni, off-v2-flash)
3. ✅ mimo-v2-pro uses threshold pricing at 256K tokens
4. ✅ Add test coverage for all MiMo models
5. ✅ All tests pass

## Changed Areas

- : Add MiMo model entries to DefaultCatalog
- : Add TestDefaultCatalogCoversMiMoModels

## Pricing Data (from official MiMo platform)

### MiMo-V2.5 Series (effective May 27, 2026)
| Model | Input (Cache Hit) | Input (Cache Miss) | Output |
|-------|-------------------|-------------------|--------|
| mimo-v2.5-pro | $0.0036/M | $0.435/M | $0.87/M |
| mimo-v2.5 | $0.0028/M | $0.14/M | $0.28/M |

### MiMo-V2 Series
| Model | Input ≤ 256K | Input 256K-1M | Output ≤ 256K | Output 256K-1M |
|-------|--------------|---------------|---------------|----------------|
| mimo-v2-pro | $1.00/M | $2.00/M | $3.00/M | $6.00/M |
| mimo-v2-omni | $0.40/M | — | $2.00/M | — |
| off-v2-flash | $0.10/M | — | $0.30/M | — |

## Release Decision

**Release required** - This adds new model pricing support.

## TDD / Test Evidence

- Added TestDefaultCatalogCoversMiMoModels covering all 6 model variants
- Verifies threshold pricing for mimo-v2-pro
- All existing tests continue to pass

## Validation

- [x]  passes
- [x] GOCACHE=/Users/sosbs/coding/aitok/.cache/aitok/go-build GOMODCACHE=/Users/sosbs/coding/aitok/.cache/aitok/go-mod go test ./...
?   	github.com/MagnumGoYB/aitok/cmd/aitok	[no test files]
ok  	github.com/MagnumGoYB/aitok/harness	0.555s
ok  	github.com/MagnumGoYB/aitok/internal/buildinfo	(cached)
ok  	github.com/MagnumGoYB/aitok/internal/cli	0.728s
ok  	github.com/MagnumGoYB/aitok/internal/pricing	(cached)
ok  	github.com/MagnumGoYB/aitok/internal/query	(cached)
ok  	github.com/MagnumGoYB/aitok/internal/report	(cached)
ok  	github.com/MagnumGoYB/aitok/internal/setup	(cached)
ok  	github.com/MagnumGoYB/aitok/internal/sources	1.347s
ok  	github.com/MagnumGoYB/aitok/internal/tui	(cached)
ok  	github.com/MagnumGoYB/aitok/internal/updatecheck	(cached)
ok  	github.com/MagnumGoYB/aitok/internal/usage	(cached)
ok  	github.com/MagnumGoYB/aitok/tools/commitlint	(cached)
ok  	github.com/MagnumGoYB/aitok/tools/pricing-watch	(cached)
ok  	github.com/MagnumGoYB/aitok/tools/validate-pr-body	(cached)
ok  	github.com/MagnumGoYB/aitok/tools/version	(cached) passes
- [x] GOCACHE=/Users/sosbs/coding/aitok/.cache/aitok/go-build GOMODCACHE=/Users/sosbs/coding/aitok/.cache/aitok/go-mod go build ./cmd/aitok succeeds

## Risk and Rollback

**Risk:** Low - Additive change, only adds new pricing entries

**Rollback:** Revert commit 8750821

**Residual risks:** None identified