### PR TITLE
🐛 fix: price Claude Opus 5

### DIFF
--- a/docs/pricing-sources.json
+++ b/docs/pricing-sources.json
@@ -14,9 +14,9 @@
       "url": "https://docs.anthropic.com/en/docs/about-claude/pricing",
       "manual_review": true,
       "sha256": "",
-      "required_text": ["Claude Opus 4.7", "Claude Sonnet 4.5", "1h Cache writes", "Cache reads"],
+      "required_text": ["Claude Opus 5", "Claude Opus 4.7", "Claude Sonnet 4.5", "1h Cache writes", "Cache reads"],
       "review_hint": "Review Claude model input/output, 5m cache write, 1h cache write, and cache read pricing. Update claude-* defaults when official prices change.",
-      "models_owned": ["claude-opus-4-7", "claude-opus-4-6", "claude-opus-4-5", "claude-opus-4", "claude-sonnet-4-6", "claude-sonnet-4-5", "claude-sonnet-4", "claude-haiku-4-5", "claude-3-7-sonnet", "claude-3-5-haiku", "claude-3-haiku"]
+      "models_owned": ["claude-opus-5", "claude-opus-4-7", "claude-opus-4-6", "claude-opus-4-5", "claude-opus-4", "claude-sonnet-4-6", "claude-sonnet-4-5", "claude-sonnet-4", "claude-haiku-4-5", "claude-3-7-sonnet", "claude-3-5-haiku", "claude-3-haiku"]
     },
     {
       "name": "gemini",

--- a/internal/pricing/pricing.go
+++ b/internal/pricing/pricing.go
@@ -81,6 +81,7 @@ func DefaultCatalog() Catalog {
 		{Match: "gpt-4o", Provider: "openai", InputUSDPerMTok: 2.5, OutputUSDPerMTok: 10, CacheHitUSDPerMTok: 1.25, CacheMakeUSDPerMTok: 2.5, Multiplier: 1, Source: "default"},
 		// Introductory Anthropic pricing through 2026-08-31; standard rates start 2026-09-01.
 		{Match: "claude-sonnet-5", Provider: "anthropic", InputUSDPerMTok: 2, OutputUSDPerMTok: 10, CacheHitUSDPerMTok: 0.2, CacheMakeUSDPerMTok: 2.5, CacheMake1hUSDPerMTok: 4, Multiplier: 1, Source: "default"},
+		{Match: "claude-opus-5", Provider: "anthropic", InputUSDPerMTok: 5, OutputUSDPerMTok: 25, CacheHitUSDPerMTok: 0.5, CacheMakeUSDPerMTok: 6.25, CacheMake1hUSDPerMTok: 10, Multiplier: 1, Source: "default"},
 		{Match: "claude-opus-4-7", Provider: "anthropic", InputUSDPerMTok: 5, OutputUSDPerMTok: 25, CacheHitUSDPerMTok: 0.5, CacheMakeUSDPerMTok: 6.25, CacheMake1hUSDPerMTok: 10, Multiplier: 1, Source: "default"},
 		{Match: "claude-opus-4-6", Provider: "anthropic", InputUSDPerMTok: 5, OutputUSDPerMTok: 25, CacheHitUSDPerMTok: 0.5, CacheMakeUSDPerMTok: 6.25, CacheMake1hUSDPerMTok: 10, Multiplier: 1, Source: "default"},
 		{Match: "claude-opus-4-5", Provider: "anthropic", InputUSDPerMTok: 5, OutputUSDPerMTok: 25, CacheHitUSDPerMTok: 0.5, CacheMakeUSDPerMTok: 6.25, CacheMake1hUSDPerMTok: 10, Multiplier: 1, Source: "default"},

--- a/internal/pricing/pricing_test.go
+++ b/internal/pricing/pricing_test.go
@@ -160,6 +160,21 @@ func TestDefaultCatalogPricesClaudeOpus47BeforeOpus4(t *testing.T) {
 	}
 }
 
+func TestDefaultCatalogCoversClaudeOpus5(t *testing.T) {
+	cost := DefaultCatalog().CostFor(usage.UsageEvent{
+		Tool:     usage.ToolClaude,
+		Model:    "claude-opus-5",
+		Provider: "anthropic",
+		Usage:    usage.TokenUsage{Input: 1_000_000},
+	})
+	if cost.Source != "default" {
+		t.Fatalf("claude-opus-5 should be priced by default: %+v", cost)
+	}
+	if cost.InputUSDPerMTok != 5 || cost.OutputUSDPerMTok != 25 || cost.CacheHitUSDPerMTok != 0.5 || cost.CacheMakeUSDPerMTok != 6.25 || cost.CacheMake1hUSDPerMTok != 10 {
+		t.Fatalf("claude-opus-5 rates do not match Anthropic pricing: %+v", cost)
+	}
+}
+
 func TestCostForGemini25ProUsesAboveThresholdPricing(t *testing.T) {
 	cost := DefaultCatalog().CostFor(usage.UsageEvent{
 		Tool:     usage.ToolGemini,


### PR DESCRIPTION
## Summary

- Add official default pricing for Claude Opus 5 so local usage is no longer reported as unpriced.
- Track Claude Opus 5 in the Anthropic pricing-source metadata.

## Requirement Classification

- Type: Bugfix
- User-visible outcome: `claude-opus-5` usage receives offline cost estimates instead of appearing in `pricing audit` as unpriced.
- Target platform(s): All supported CLI platforms
- Scope assumptions: Standard Anthropic API pricing only; fast mode and regional premiums remain out of scope because usage events do not expose those billing modifiers.

## Acceptance Criteria

- [x] Criteria are written before implementation starts.
- [x] Each criterion maps to unit test coverage where practical.
- [x] Each criterion maps to CLI/manual/platform evidence where relevant.
- [x] At least one failure or edge case is covered, or a reason is documented.

## Changed Areas

- `internal/pricing`: bundled model rates and regression coverage
- `docs/pricing-sources.json`: Anthropic source ownership and required text

## Release Decision

- Release required after merge: publish patch release `v0.3.5`.

## TDD / Test Evidence

- Test/sensor added before implementation: `TestDefaultCatalogCoversClaudeOpus5` first failed with `Source: unknown`.
- Unit tests: Regression asserts the official input, output, cache-read, 5m cache-write, and 1h cache-write rates.
- CLI/manual/platform evidence: `aitok --no-version-check pricing audit --period this-month --format json` returned `"unpriced": []` after the fix.
- Failure and edge cases covered: Exact previously-unpriced model/provider pair is exercised; unsupported billing modifiers are not inferred.
- Acceptance criteria evidence map: Default coverage and rates use the unit test; removal from the audit uses the local CLI smoke.

## Validation

- [x] `make check`
- [x] `make test`
- [x] `make test-harness`
- [x] `make build`
- [x] `make validate` (includes generate; run when VERSION changed)
- [x] Commit message follows `go run ./tools/commitlint --edit <commit-msg-file>`
- Skipped validation and reason: None.

## Risk and Rollback

- Risk: Cost estimates use standard Anthropic rates and do not account for fast mode or regional premiums.
- Rollback: Revert the pricing catalog entry, source metadata, and regression test.
- Residual risk: Provider-specific billing modifiers remain unpriced unless represented in local event metadata.